### PR TITLE
Add Calendar component

### DIFF
--- a/lib/phlexy_ui/calendar.rb
+++ b/lib/phlexy_ui/calendar.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+module PhlexyUI
+  # @component html class="cally" or class="pika-single"
+  # Supports Cally web component and Pikaday date picker
+  class Calendar < Base
+    # Register custom web component elements
+    register_element :calendar_date
+    register_element :calendar_month
+
+    def initialize(*, type: :cally, **)
+      super(*, **)
+      @type = type
+    end
+
+    def view_template(&)
+      case type
+      when :cally
+        render_cally(&)
+      when :pikaday
+        render_pikaday
+      end
+    end
+
+    private
+
+    attr_reader :type
+
+    def render_cally(&block)
+      generate_classes!(
+        # "cally"
+        component_html_class: :cally,
+        modifiers_map: modifiers,
+        base_modifiers:,
+        options:
+      ).then do |classes|
+        calendar_date(class: classes, **options, &block)
+      end
+    end
+
+    def render_pikaday
+      generate_classes!(
+        # "input pika-single"
+        component_html_class: "input pika-single",
+        modifiers_map: modifiers,
+        base_modifiers:,
+        options:
+      ).then do |classes|
+        input(type: :text, class: classes, **options)
+      end
+    end
+  end
+end

--- a/spec/lib/phlexy_ui/calendar_spec.rb
+++ b/spec/lib/phlexy_ui/calendar_spec.rb
@@ -1,0 +1,59 @@
+require "spec_helper"
+
+describe PhlexyUI::Calendar do
+  describe "Cally calendar (default)" do
+    subject(:output) { render described_class.new }
+
+    it "is expected to match the formatted HTML" do
+      expected_html = html <<~HTML
+        <calendar-date class="cally"></calendar-date>
+      HTML
+
+      is_expected.to eq(expected_html)
+    end
+
+    context "with block content" do
+      subject(:output) do
+        render described_class.new do |c|
+          c.calendar_month
+        end
+      end
+
+      it "renders with content" do
+        expected_html = html <<~HTML
+          <calendar-date class="cally">
+            <calendar-month></calendar-month>
+          </calendar-date>
+        HTML
+
+        expect(output).to eq(expected_html)
+      end
+    end
+  end
+
+  describe "Pikaday calendar" do
+    subject(:output) { render described_class.new(type: :pikaday) }
+
+    it "renders as input with pika-single class" do
+      expected_html = html <<~HTML
+        <input type="text" class="input pika-single">
+      HTML
+
+      expect(output).to eq(expected_html)
+    end
+  end
+
+  describe "data" do
+    subject(:output) do
+      render described_class.new(data: {foo: "bar"})
+    end
+
+    it "renders it correctly" do
+      expected_html = html <<~HTML
+        <calendar-date class="cally" data-foo="bar"></calendar-date>
+      HTML
+
+      expect(output).to eq(expected_html)
+    end
+  end
+end


### PR DESCRIPTION
This PR adds the Calendar component from #5.

## Changes
- Adds `PhlexyUI::Calendar` component
- Includes comprehensive test coverage
- Follows PhlexyUI patterns and conventions

Part of breaking up #5 into individual component PRs.