### PR TITLE
Add Carousel component

### DIFF
--- a/lib/phlexy_ui/carousel.rb
+++ b/lib/phlexy_ui/carousel.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+module PhlexyUI
+  # @component html class="carousel"
+  class Carousel < Base
+    def initialize(*, as: :div, **)
+      super(*, **)
+      @as = as
+    end
+
+    def view_template(&)
+      generate_classes!(
+        # "carousel"
+        component_html_class: :carousel,
+        modifiers_map: modifiers,
+        base_modifiers:,
+        options:
+      ).then do |classes|
+        public_send(as, class: classes, **options, &)
+      end
+    end
+
+    def item(**options, &)
+      generate_classes!(
+        # "carousel-item"
+        component_html_class: :"carousel-item",
+        options:
+      ).then do |classes|
+        div(class: classes, **options, &)
+      end
+    end
+
+    register_modifiers(
+      # "sm:carousel-start"
+      # "@sm:carousel-start"
+      # "md:carousel-start"
+      # "@md:carousel-start"
+      # "lg:carousel-start"
+      # "@lg:carousel-start"
+      start: "carousel-start",
+      # "sm:carousel-center"
+      # "@sm:carousel-center"
+      # "md:carousel-center"
+      # "@md:carousel-center"
+      # "lg:carousel-center"
+      # "@lg:carousel-center"
+      center: "carousel-center",
+        # "sm:carousel-end"
+        # "@sm:carousel-end"
+        # "md:carousel-end"
+        # "@md:carousel-end"
+        # "lg:carousel-end"
+        # "@lg:carousel-end"
+      end: "carousel-end",
+      # "sm:carousel-vertical"
+      # "@sm:carousel-vertical"
+      # "md:carousel-vertical"
+      # "@md:carousel-vertical"
+      # "lg:carousel-vertical"
+      # "@lg:carousel-vertical"
+      vertical: "carousel-vertical"
+    )
+  end
+end

--- a/lib/phlexy_ui/carousel.rb
+++ b/lib/phlexy_ui/carousel.rb
@@ -58,7 +58,14 @@ module PhlexyUI
       # "@md:carousel-vertical"
       # "lg:carousel-vertical"
       # "@lg:carousel-vertical"
-      vertical: "carousel-vertical"
+      vertical: "carousel-vertical",
+      # "sm:carousel-horizontal"
+      # "@sm:carousel-horizontal"
+      # "md:carousel-horizontal"
+      # "@md:carousel-horizontal"
+      # "lg:carousel-horizontal"
+      # "@lg:carousel-horizontal"
+      horizontal: "carousel-horizontal"
     )
   end
 end

--- a/spec/lib/phlexy_ui/carousel_spec.rb
+++ b/spec/lib/phlexy_ui/carousel_spec.rb
@@ -36,7 +36,8 @@ describe PhlexyUI::Carousel do
       start: "carousel-start",
       center: "carousel-center",
       end: "carousel-end",
-      vertical: "carousel-vertical"
+      vertical: "carousel-vertical",
+      horizontal: "carousel-horizontal"
     }.each do |modifier, css|
       context "when given :#{modifier} modifier" do
         subject(:output) { render described_class.new(modifier) }

--- a/spec/lib/phlexy_ui/carousel_spec.rb
+++ b/spec/lib/phlexy_ui/carousel_spec.rb
@@ -1,0 +1,110 @@
+require "spec_helper"
+
+describe PhlexyUI::Carousel do
+  subject(:output) { render described_class.new }
+
+  it "is expected to match the formatted HTML" do
+    expected_html = html <<~HTML
+      <div class="carousel"></div>
+    HTML
+
+    is_expected.to eq(expected_html)
+  end
+
+  describe "with item method" do
+    subject(:output) do
+      render described_class.new do |c|
+        c.item { "Item 1" }
+        c.item { "Item 2" }
+      end
+    end
+
+    it "renders items" do
+      expected_html = html <<~HTML
+        <div class="carousel">
+          <div class="carousel-item">Item 1</div>
+          <div class="carousel-item">Item 2</div>
+        </div>
+      HTML
+
+      expect(output).to eq(expected_html)
+    end
+  end
+
+  describe "conditions" do
+    {
+      start: "carousel-start",
+      center: "carousel-center",
+      end: "carousel-end",
+      vertical: "carousel-vertical"
+    }.each do |modifier, css|
+      context "when given :#{modifier} modifier" do
+        subject(:output) { render described_class.new(modifier) }
+
+        it "renders it apart from the main class" do
+          expected_html = html <<~HTML
+            <div class="carousel #{css}"></div>
+          HTML
+
+          expect(output).to eq(expected_html)
+        end
+      end
+    end
+
+    context "when given multiple conditions" do
+      subject(:output) { render described_class.new(:center, :vertical) }
+
+      it "renders them separately" do
+        expected_html = html <<~HTML
+          <div class="carousel carousel-center carousel-vertical"></div>
+        HTML
+
+        expect(output).to eq(expected_html)
+      end
+    end
+  end
+
+  describe "data" do
+    subject(:output) do
+      render described_class.new(data: {foo: "bar"})
+    end
+
+    it "renders it correctly" do
+      expected_html = html <<~HTML
+        <div class="carousel" data-foo="bar"></div>
+      HTML
+
+      expect(output).to eq(expected_html)
+    end
+  end
+
+  describe "responsiveness" do
+    %i[sm md lg xl @sm @md @lg @xl].each do |viewport|
+      context "when given an :#{viewport} responsive option" do
+        subject(:output) do
+          render described_class.new(:start, responsive: {viewport => :center})
+        end
+
+        it "renders it separately with a responsive prefix" do
+          expected_html = html <<~HTML
+            <div class="carousel carousel-start #{viewport}:carousel-center"></div>
+          HTML
+
+          expect(output).to eq(expected_html)
+        end
+      end
+    end
+  end
+
+  describe "passing :as option" do
+    subject(:output) { render described_class.new(as: :section) }
+
+    it "renders as the given tag" do
+      expected_html = html <<~HTML
+        <section class="carousel"></section>
+      HTML
+
+      expect(output).to eq(expected_html)
+    end
+  end
+end


### PR DESCRIPTION
This PR adds the Carousel component from #5.

## Changes
- Adds `PhlexyUI::Carousel` component
- Includes comprehensive test coverage
- Follows PhlexyUI patterns and conventions

Part of breaking up #5 into individual component PRs.
