### PR TITLE
Add Diff component

### DIFF
--- a/lib/phlexy_ui/diff.rb
+++ b/lib/phlexy_ui/diff.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+module PhlexyUI
+  # @component html class="diff"
+  class Diff < Base
+    def initialize(*, as: :figure, **)
+      super(*, **)
+      @as = as
+    end
+
+    def view_template(&)
+      generate_classes!(
+        # "diff"
+        component_html_class: :diff,
+        modifiers_map: modifiers,
+        base_modifiers:,
+        options:
+      ).then do |classes|
+        public_send(as, class: classes, **options, &)
+      end
+    end
+
+    def item_1(**options, &)
+      generate_classes!(
+        # "diff-item-1"
+        component_html_class: :"diff-item-1",
+        options:
+      ).then do |classes|
+        div(class: classes, **options, &)
+      end
+    end
+
+    def item_2(**options, &)
+      generate_classes!(
+        # "diff-item-2"
+        component_html_class: :"diff-item-2",
+        options:
+      ).then do |classes|
+        div(class: classes, **options, &)
+      end
+    end
+
+    def resizer(**options, &)
+      generate_classes!(
+        # "diff-resizer"
+        component_html_class: :"diff-resizer",
+        options:
+      ).then do |classes|
+        div(class: classes, **options, &)
+      end
+    end
+  end
+end

--- a/spec/lib/phlexy_ui/diff_spec.rb
+++ b/spec/lib/phlexy_ui/diff_spec.rb
@@ -1,0 +1,61 @@
+require "spec_helper"
+
+describe PhlexyUI::Diff do
+  subject(:output) { render described_class.new }
+
+  it "is expected to match the formatted HTML" do
+    expected_html = html <<~HTML
+      <figure class="diff"></figure>
+    HTML
+
+    is_expected.to eq(expected_html)
+  end
+
+  describe "with part methods" do
+    subject(:output) do
+      render described_class.new do |d|
+        d.item_1 { "Item 1" }
+        d.resizer
+        d.item_2 { "Item 2" }
+      end
+    end
+
+    it "renders all parts" do
+      expected_html = html <<~HTML
+        <figure class="diff">
+          <div class="diff-item-1">Item 1</div>
+          <div class="diff-resizer"></div>
+          <div class="diff-item-2">Item 2</div>
+        </figure>
+      HTML
+
+      expect(output).to eq(expected_html)
+    end
+  end
+
+  describe "data" do
+    subject(:output) do
+      render described_class.new(data: {foo: "bar"})
+    end
+
+    it "renders it correctly" do
+      expected_html = html <<~HTML
+        <figure class="diff" data-foo="bar"></figure>
+      HTML
+
+      expect(output).to eq(expected_html)
+    end
+  end
+
+  describe "passing :as option" do
+    subject(:output) { render described_class.new(as: :div) }
+
+    it "renders as the given tag" do
+      expected_html = html <<~HTML
+        <div class="diff"></div>
+      HTML
+
+      expect(output).to eq(expected_html)
+    end
+  end
+end


### PR DESCRIPTION
This PR adds the Diff component from #5.

## Changes
- Adds `PhlexyUI::Diff` component
- Includes comprehensive test coverage
- Follows PhlexyUI patterns and conventions

Part of breaking up #5 into individual component PRs.
