### PR TITLE
Add Divider component

### DIFF
--- a/lib/phlexy_ui/divider.rb
+++ b/lib/phlexy_ui/divider.rb
@@ -1,0 +1,110 @@
+# frozen_string_literal: true
+
+module PhlexyUI
+  # @component html class="divider"
+  class Divider < Base
+    def initialize(*, as: :div, **)
+      super(*, **)
+      @as = as
+    end
+
+    def view_template(&)
+      generate_classes!(
+        # "divider"
+        component_html_class: :divider,
+        modifiers_map: modifiers,
+        base_modifiers:,
+        options:
+      ).then do |classes|
+        public_send(as, class: classes, **options, &)
+      end
+    end
+
+    register_modifiers(
+      # "sm:divider-vertical"
+      # "@sm:divider-vertical"
+      # "md:divider-vertical"
+      # "@md:divider-vertical"
+      # "lg:divider-vertical"
+      # "@lg:divider-vertical"
+      vertical: "divider-vertical",
+      # "sm:divider-horizontal"
+      # "@sm:divider-horizontal"
+      # "md:divider-horizontal"
+      # "@md:divider-horizontal"
+      # "lg:divider-horizontal"
+      # "@lg:divider-horizontal"
+      horizontal: "divider-horizontal",
+      # "sm:divider-start"
+      # "@sm:divider-start"
+      # "md:divider-start"
+      # "@md:divider-start"
+      # "lg:divider-start"
+      # "@lg:divider-start"
+      start: "divider-start",
+        # "sm:divider-end"
+        # "@sm:divider-end"
+        # "md:divider-end"
+        # "@md:divider-end"
+        # "lg:divider-end"
+        # "@lg:divider-end"
+      end: "divider-end",
+      # "sm:divider-neutral"
+      # "@sm:divider-neutral"
+      # "md:divider-neutral"
+      # "@md:divider-neutral"
+      # "lg:divider-neutral"
+      # "@lg:divider-neutral"
+      neutral: "divider-neutral",
+      # "sm:divider-primary"
+      # "@sm:divider-primary"
+      # "md:divider-primary"
+      # "@md:divider-primary"
+      # "lg:divider-primary"
+      # "@lg:divider-primary"
+      primary: "divider-primary",
+      # "sm:divider-secondary"
+      # "@sm:divider-secondary"
+      # "md:divider-secondary"
+      # "@md:divider-secondary"
+      # "lg:divider-secondary"
+      # "@lg:divider-secondary"
+      secondary: "divider-secondary",
+      # "sm:divider-accent"
+      # "@sm:divider-accent"
+      # "md:divider-accent"
+      # "@md:divider-accent"
+      # "lg:divider-accent"
+      # "@lg:divider-accent"
+      accent: "divider-accent",
+      # "sm:divider-success"
+      # "@sm:divider-success"
+      # "md:divider-success"
+      # "@md:divider-success"
+      # "lg:divider-success"
+      # "@lg:divider-success"
+      success: "divider-success",
+      # "sm:divider-warning"
+      # "@sm:divider-warning"
+      # "md:divider-warning"
+      # "@md:divider-warning"
+      # "lg:divider-warning"
+      # "@lg:divider-warning"
+      warning: "divider-warning",
+      # "sm:divider-info"
+      # "@sm:divider-info"
+      # "md:divider-info"
+      # "@md:divider-info"
+      # "lg:divider-info"
+      # "@lg:divider-info"
+      info: "divider-info",
+      # "sm:divider-error"
+      # "@sm:divider-error"
+      # "md:divider-error"
+      # "@md:divider-error"
+      # "lg:divider-error"
+      # "@lg:divider-error"
+      error: "divider-error"
+    )
+  end
+end

--- a/lib/phlexy_ui/divider.rb
+++ b/lib/phlexy_ui/divider.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 module PhlexyUI
-  # @component html class="divider"
   class Divider < Base
     def initialize(*, as: :div, **)
       super(*, **)

--- a/spec/lib/phlexy_ui/divider_spec.rb
+++ b/spec/lib/phlexy_ui/divider_spec.rb
@@ -1,0 +1,98 @@
+require "spec_helper"
+
+describe PhlexyUI::Divider do
+  subject(:output) { render described_class.new }
+
+  it "is expected to match the formatted HTML" do
+    expected_html = html <<~HTML
+      <div class="divider"></div>
+    HTML
+
+    is_expected.to eq(expected_html)
+  end
+
+  describe "conditions" do
+    {
+      vertical: "divider-vertical",
+      horizontal: "divider-horizontal",
+      start: "divider-start",
+      end: "divider-end",
+      neutral: "divider-neutral",
+      primary: "divider-primary",
+      secondary: "divider-secondary",
+      accent: "divider-accent",
+      success: "divider-success",
+      warning: "divider-warning",
+      info: "divider-info",
+      error: "divider-error"
+    }.each do |modifier, css|
+      context "when given :#{modifier} modifier" do
+        subject(:output) { render described_class.new(modifier) }
+
+        it "renders it apart from the main class" do
+          expected_html = html <<~HTML
+            <div class="divider #{css}"></div>
+          HTML
+
+          expect(output).to eq(expected_html)
+        end
+      end
+    end
+
+    context "when given multiple conditions" do
+      subject(:output) { render described_class.new(:vertical, :primary) }
+
+      it "renders them separately" do
+        expected_html = html <<~HTML
+          <div class="divider divider-vertical divider-primary"></div>
+        HTML
+
+        expect(output).to eq(expected_html)
+      end
+    end
+  end
+
+  describe "data" do
+    subject(:output) do
+      render described_class.new(data: {foo: "bar"})
+    end
+
+    it "renders it correctly" do
+      expected_html = html <<~HTML
+        <div class="divider" data-foo="bar"></div>
+      HTML
+
+      expect(output).to eq(expected_html)
+    end
+  end
+
+  describe "responsiveness" do
+    %i[sm md lg xl @sm @md @lg @xl].each do |viewport|
+      context "when given an :#{viewport} responsive option" do
+        subject(:output) do
+          render described_class.new(:vertical, responsive: {viewport => :horizontal})
+        end
+
+        it "renders it separately with a responsive prefix" do
+          expected_html = html <<~HTML
+            <div class="divider divider-vertical #{viewport}:divider-horizontal"></div>
+          HTML
+
+          expect(output).to eq(expected_html)
+        end
+      end
+    end
+  end
+
+  describe "passing :as option" do
+    subject(:output) { render described_class.new(as: :hr) }
+
+    it "renders as the given tag" do
+      expected_html = html <<~HTML
+        <hr class="divider">
+      HTML
+
+      expect(output).to eq(expected_html)
+    end
+  end
+end

--- a/spec/lib/phlexy_ui/divider_spec.rb
+++ b/spec/lib/phlexy_ui/divider_spec.rb
@@ -95,4 +95,56 @@ describe PhlexyUI::Divider do
       expect(output).to eq(expected_html)
     end
   end
+
+  describe "rendering via Kit" do
+    subject(:output) do
+      Divider :horizontal, data: {foo: "bar"}, class: "my-divider"
+    end
+
+    it "renders it correctly" do
+      expected_html = html <<~HTML
+        <div class="divider divider-horizontal my-divider" data-foo="bar"></div>
+      HTML
+
+      expect(output).to eq(expected_html)
+    end
+  end
+
+  describe "rendering a full divider" do
+    let(:component) do
+      Class.new(Phlex::HTML) do
+        def view_template(&)
+          div(class: "flex w-full") do
+            render PhlexyUI::Divider.new(:horizontal, data: {foo: "bar"}, class: "my-divider")
+            render PhlexyUI::Divider.new(:horizontal, :start) do
+              "Start"
+            end
+            render PhlexyUI::Divider.new(:horizontal) do
+              "Default"
+            end
+            render PhlexyUI::Divider.new(:horizontal, :end) do
+              "End"
+            end
+          end
+        end
+      end
+    end
+
+    subject(:output) do
+      render component.new
+    end
+
+    it "renders it correctly" do
+      expected_html = html <<~HTML
+        <div class="flex w-full">
+          <div class="divider divider-horizontal my-divider" data-foo="bar"></div>
+          <div class="divider divider-horizontal divider-start">Start</div>
+          <div class="divider divider-horizontal">Default</div>
+          <div class="divider divider-horizontal divider-end">End</div>
+        </div>
+      HTML
+
+      expect(output).to eq(expected_html)
+    end
+  end
 end


### PR DESCRIPTION
This PR adds the Divider component from #5.

## Changes
- Adds `PhlexyUI::Divider` component
- Includes comprehensive test coverage
- Follows PhlexyUI patterns and conventions

Part of breaking up #5 into individual component PRs.
