### PR TITLE
Add Dock component

### DIFF
--- a/lib/phlexy_ui/dock.rb
+++ b/lib/phlexy_ui/dock.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+module PhlexyUI
+  # @component html class="dock"
+  class Dock < Base
+    def initialize(*, as: :div, **)
+      super(*, **)
+      @as = as
+    end
+
+    def view_template(&)
+      generate_classes!(
+        # "dock"
+        component_html_class: :dock,
+        modifiers_map: modifiers,
+        base_modifiers:,
+        options:
+      ).then do |classes|
+        public_send(as, class: classes, **options, &)
+      end
+    end
+
+    def label(**options, &)
+      generate_classes!(
+        # "dock-label"
+        component_html_class: :"dock-label",
+        options:
+      ).then do |classes|
+        span(class: classes, **options, &)
+      end
+    end
+
+    register_modifiers(
+      # "sm:dock-active"
+      # "@sm:dock-active"
+      # "md:dock-active"
+      # "@md:dock-active"
+      # "lg:dock-active"
+      # "@lg:dock-active"
+      active: "dock-active",
+      # "sm:dock-xs"
+      # "@sm:dock-xs"
+      # "md:dock-xs"
+      # "@md:dock-xs"
+      # "lg:dock-xs"
+      # "@lg:dock-xs"
+      xs: "dock-xs",
+      # "sm:dock-sm"
+      # "@sm:dock-sm"
+      # "md:dock-sm"
+      # "@md:dock-sm"
+      # "lg:dock-sm"
+      # "@lg:dock-sm"
+      sm: "dock-sm",
+      # "sm:dock-md"
+      # "@sm:dock-md"
+      # "md:dock-md"
+      # "@md:dock-md"
+      # "lg:dock-md"
+      # "@lg:dock-md"
+      md: "dock-md",
+      # "sm:dock-lg"
+      # "@sm:dock-lg"
+      # "md:dock-lg"
+      # "@md:dock-lg"
+      # "lg:dock-lg"
+      # "@lg:dock-lg"
+      lg: "dock-lg",
+      # "sm:dock-xl"
+      # "@sm:dock-xl"
+      # "md:dock-xl"
+      # "@md:dock-xl"
+      # "lg:dock-xl"
+      # "@lg:dock-xl"
+      xl: "dock-xl"
+    )
+  end
+end

--- a/spec/lib/phlexy_ui/dock_spec.rb
+++ b/spec/lib/phlexy_ui/dock_spec.rb
@@ -1,0 +1,110 @@
+require "spec_helper"
+
+describe PhlexyUI::Dock do
+  subject(:output) { render described_class.new }
+
+  it "is expected to match the formatted HTML" do
+    expected_html = html <<~HTML
+      <div class="dock"></div>
+    HTML
+
+    is_expected.to eq(expected_html)
+  end
+
+  describe "with label method" do
+    subject(:output) do
+      render described_class.new do |d|
+        d.label { "Label" }
+      end
+    end
+
+    it "renders label" do
+      expected_html = html <<~HTML
+        <div class="dock">
+          <span class="dock-label">Label</span>
+        </div>
+      HTML
+
+      expect(output).to eq(expected_html)
+    end
+  end
+
+  describe "conditions" do
+    {
+      active: "dock-active",
+      xs: "dock-xs",
+      sm: "dock-sm",
+      md: "dock-md",
+      lg: "dock-lg",
+      xl: "dock-xl"
+    }.each do |modifier, css|
+      context "when given :#{modifier} modifier" do
+        subject(:output) { render described_class.new(modifier) }
+
+        it "renders it apart from the main class" do
+          expected_html = html <<~HTML
+            <div class="dock #{css}"></div>
+          HTML
+
+          expect(output).to eq(expected_html)
+        end
+      end
+    end
+
+    context "when given multiple conditions" do
+      subject(:output) { render described_class.new(:active, :lg) }
+
+      it "renders them separately" do
+        expected_html = html <<~HTML
+          <div class="dock dock-active dock-lg"></div>
+        HTML
+
+        expect(output).to eq(expected_html)
+      end
+    end
+  end
+
+  describe "data" do
+    subject(:output) do
+      render described_class.new(data: {foo: "bar"})
+    end
+
+    it "renders it correctly" do
+      expected_html = html <<~HTML
+        <div class="dock" data-foo="bar"></div>
+      HTML
+
+      expect(output).to eq(expected_html)
+    end
+  end
+
+  describe "responsiveness" do
+    %i[sm md lg xl @sm @md @lg @xl].each do |viewport|
+      context "when given an :#{viewport} responsive option" do
+        subject(:output) do
+          render described_class.new(:sm, responsive: {viewport => :lg})
+        end
+
+        it "renders it separately with a responsive prefix" do
+          expected_html = html <<~HTML
+            <div class="dock dock-sm #{viewport}:dock-lg"></div>
+          HTML
+
+          expect(output).to eq(expected_html)
+        end
+      end
+    end
+  end
+
+  describe "passing :as option" do
+    subject(:output) { render described_class.new(as: :section) }
+
+    it "renders as the given tag" do
+      expected_html = html <<~HTML
+        <section class="dock"></section>
+      HTML
+
+      expect(output).to eq(expected_html)
+    end
+  end
+end


### PR DESCRIPTION
This PR adds the Dock component from #5.

## Changes
- Adds `PhlexyUI::Dock` component
- Includes comprehensive test coverage
- Follows PhlexyUI patterns and conventions

Part of breaking up #5 into individual component PRs.
