### PR TITLE
Add Fab component

### DIFF
--- a/lib/phlexy_ui/fab.rb
+++ b/lib/phlexy_ui/fab.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+module PhlexyUI
+  # @component html class="fab"
+  class Fab < Base
+    def initialize(*, as: :div, **)
+      super(*, **)
+      @as = as
+    end
+
+    def view_template(&)
+      generate_classes!(
+        # "fab"
+        component_html_class: :fab,
+        modifiers_map: modifiers,
+        base_modifiers:,
+        options:
+      ).then do |classes|
+        public_send(as, class: classes, **options, &)
+      end
+    end
+
+    def close(**options, &)
+      generate_classes!(
+        # "fab-close"
+        component_html_class: :"fab-close",
+        options:
+      ).then do |classes|
+        div(class: classes, **options, &)
+      end
+    end
+
+    def main_action(**options, &)
+      generate_classes!(
+        # "fab-main-action"
+        component_html_class: :"fab-main-action",
+        options:
+      ).then do |classes|
+        div(class: classes, **options, &)
+      end
+    end
+
+    register_modifiers(
+      # "sm:fab-flower"
+      # "@sm:fab-flower"
+      # "md:fab-flower"
+      # "@md:fab-flower"
+      # "lg:fab-flower"
+      # "@lg:fab-flower"
+      flower: "fab-flower"
+    )
+  end
+end

--- a/spec/lib/phlexy_ui/fab_spec.rb
+++ b/spec/lib/phlexy_ui/fab_spec.rb
@@ -1,0 +1,95 @@
+require "spec_helper"
+
+describe PhlexyUI::Fab do
+  subject(:output) { render described_class.new }
+
+  it "is expected to match the formatted HTML" do
+    expected_html = html <<~HTML
+      <div class="fab"></div>
+    HTML
+
+    is_expected.to eq(expected_html)
+  end
+
+  describe "with part methods" do
+    subject(:output) do
+      render described_class.new do |f|
+        f.close { "Close" }
+        f.main_action { "Action" }
+      end
+    end
+
+    it "renders all parts" do
+      expected_html = html <<~HTML
+        <div class="fab">
+          <div class="fab-close">Close</div>
+          <div class="fab-main-action">Action</div>
+        </div>
+      HTML
+
+      expect(output).to eq(expected_html)
+    end
+  end
+
+  describe "conditions" do
+    {
+      flower: "fab-flower"
+    }.each do |modifier, css|
+      context "when given :#{modifier} modifier" do
+        subject(:output) { render described_class.new(modifier) }
+
+        it "renders it apart from the main class" do
+          expected_html = html <<~HTML
+            <div class="fab #{css}"></div>
+          HTML
+
+          expect(output).to eq(expected_html)
+        end
+      end
+    end
+  end
+
+  describe "data" do
+    subject(:output) do
+      render described_class.new(data: {foo: "bar"})
+    end
+
+    it "renders it correctly" do
+      expected_html = html <<~HTML
+        <div class="fab" data-foo="bar"></div>
+      HTML
+
+      expect(output).to eq(expected_html)
+    end
+  end
+
+  describe "responsiveness" do
+    %i[sm md lg xl @sm @md @lg @xl].each do |viewport|
+      context "when given an :#{viewport} responsive option" do
+        subject(:output) do
+          render described_class.new(:flower, responsive: {viewport => :flower})
+        end
+
+        it "renders it separately with a responsive prefix" do
+          expected_html = html <<~HTML
+            <div class="fab fab-flower #{viewport}:fab-flower"></div>
+          HTML
+
+          expect(output).to eq(expected_html)
+        end
+      end
+    end
+  end
+
+  describe "passing :as option" do
+    subject(:output) { render described_class.new(as: :section) }
+
+    it "renders as the given tag" do
+      expected_html = html <<~HTML
+        <section class="fab"></section>
+      HTML
+
+      expect(output).to eq(expected_html)
+    end
+  end
+end


### PR DESCRIPTION
This PR adds the Fab component from #5.

## Changes
- Adds `PhlexyUI::Fab` component
- Includes comprehensive test coverage
- Follows PhlexyUI patterns and conventions

Part of breaking up #5 into individual component PRs.
