### PR TITLE
Add Fieldset component

### DIFF
--- a/lib/phlexy_ui/fieldset.rb
+++ b/lib/phlexy_ui/fieldset.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module PhlexyUI
+  # @component html class="fieldset"
+  class Fieldset < Base
+    def initialize(*, as: :fieldset, **)
+      super(*, **)
+      @as = as
+    end
+
+    def view_template(&)
+      generate_classes!(
+        # "fieldset"
+        component_html_class: :fieldset,
+        modifiers_map: modifiers,
+        base_modifiers:,
+        options:
+      ).then do |classes|
+        public_send(as, class: classes, **options, &)
+      end
+    end
+
+    def legend(**options, &)
+      generate_classes!(
+        # "fieldset-legend"
+        component_html_class: :"fieldset-legend",
+        options:
+      ).then do |classes|
+        super(class: classes, **options, &)
+      end
+    end
+  end
+end

--- a/spec/lib/phlexy_ui/fieldset_spec.rb
+++ b/spec/lib/phlexy_ui/fieldset_spec.rb
@@ -1,0 +1,57 @@
+require "spec_helper"
+
+describe PhlexyUI::Fieldset do
+  subject(:output) { render described_class.new }
+
+  it "is expected to match the formatted HTML" do
+    expected_html = html <<~HTML
+      <fieldset class="fieldset"></fieldset>
+    HTML
+
+    is_expected.to eq(expected_html)
+  end
+
+  describe "with legend method" do
+    subject(:output) do
+      render described_class.new do |f|
+        f.legend { "Legend" }
+      end
+    end
+
+    it "renders legend" do
+      expected_html = html <<~HTML
+        <fieldset class="fieldset">
+          <legend class="fieldset-legend">Legend</legend>
+        </fieldset>
+      HTML
+
+      expect(output).to eq(expected_html)
+    end
+  end
+
+  describe "data" do
+    subject(:output) do
+      render described_class.new(data: {foo: "bar"})
+    end
+
+    it "renders it correctly" do
+      expected_html = html <<~HTML
+        <fieldset class="fieldset" data-foo="bar"></fieldset>
+      HTML
+
+      expect(output).to eq(expected_html)
+    end
+  end
+
+  describe "passing :as option" do
+    subject(:output) { render described_class.new(as: :div) }
+
+    it "renders as the given tag" do
+      expected_html = html <<~HTML
+        <div class="fieldset"></div>
+      HTML
+
+      expect(output).to eq(expected_html)
+    end
+  end
+end


### PR DESCRIPTION
This PR adds the Fieldset component from #5.

## Changes
- Adds `PhlexyUI::Fieldset` component
- Includes comprehensive test coverage
- Follows PhlexyUI patterns and conventions

Part of breaking up #5 into individual component PRs.
