### PR TITLE
Add Filter component

### DIFF
--- a/lib/phlexy_ui/filter.rb
+++ b/lib/phlexy_ui/filter.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module PhlexyUI
+  # @component html class="filter"
+  class Filter < Base
+    def initialize(*, as: :div, **)
+      super(*, **)
+      @as = as
+    end
+
+    def view_template(&)
+      generate_classes!(
+        # "filter"
+        component_html_class: :filter,
+        modifiers_map: modifiers,
+        base_modifiers:,
+        options:
+      ).then do |classes|
+        public_send(as, class: classes, **options, &)
+      end
+    end
+
+    def reset(**options, &)
+      generate_classes!(
+        # "filter-reset"
+        component_html_class: :"filter-reset",
+        options:
+      ).then do |classes|
+        input(type: :radio, class: classes, **options, &)
+      end
+    end
+  end
+end

--- a/spec/lib/phlexy_ui/filter_spec.rb
+++ b/spec/lib/phlexy_ui/filter_spec.rb
@@ -1,0 +1,57 @@
+require "spec_helper"
+
+describe PhlexyUI::Filter do
+  subject(:output) { render described_class.new }
+
+  it "is expected to match the formatted HTML" do
+    expected_html = html <<~HTML
+      <div class="filter"></div>
+    HTML
+
+    is_expected.to eq(expected_html)
+  end
+
+  describe "with reset method" do
+    subject(:output) do
+      render described_class.new do |f|
+        f.reset(name: "filter")
+      end
+    end
+
+    it "renders reset" do
+      expected_html = html <<~HTML
+        <div class="filter">
+          <input type="radio" class="filter-reset" name="filter">
+        </div>
+      HTML
+
+      expect(output).to eq(expected_html)
+    end
+  end
+
+  describe "data" do
+    subject(:output) do
+      render described_class.new(data: {foo: "bar"})
+    end
+
+    it "renders it correctly" do
+      expected_html = html <<~HTML
+        <div class="filter" data-foo="bar"></div>
+      HTML
+
+      expect(output).to eq(expected_html)
+    end
+  end
+
+  describe "passing :as option" do
+    subject(:output) { render described_class.new(as: :form) }
+
+    it "renders as the given tag" do
+      expected_html = html <<~HTML
+        <form class="filter"></form>
+      HTML
+
+      expect(output).to eq(expected_html)
+    end
+  end
+end


### PR DESCRIPTION
This PR adds the Filter component from #5.

## Changes
- Adds `PhlexyUI::Filter` component
- Includes comprehensive test coverage
- Follows PhlexyUI patterns and conventions

Part of breaking up #5 into individual component PRs.
