### PR TITLE
Add Hero component

### DIFF
--- a/lib/phlexy_ui/hero.rb
+++ b/lib/phlexy_ui/hero.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+module PhlexyUI
+  # @component html class="hero"
+  class Hero < Base
+    def initialize(*, as: :div, **)
+      super(*, **)
+      @as = as
+    end
+
+    def view_template(&)
+      generate_classes!(
+        # "hero"
+        component_html_class: :hero,
+        modifiers_map: modifiers,
+        base_modifiers:,
+        options:
+      ).then do |classes|
+        public_send(as, class: classes, **options, &)
+      end
+    end
+
+    def content(**options, &)
+      generate_classes!(
+        # "hero-content"
+        component_html_class: :"hero-content",
+        options:
+      ).then do |classes|
+        div(class: classes, **options, &)
+      end
+    end
+
+    def overlay(**options, &)
+      generate_classes!(
+        # "hero-overlay"
+        component_html_class: :"hero-overlay",
+        options:
+      ).then do |classes|
+        div(class: classes, **options, &)
+      end
+    end
+  end
+end

--- a/spec/lib/phlexy_ui/hero_spec.rb
+++ b/spec/lib/phlexy_ui/hero_spec.rb
@@ -1,0 +1,59 @@
+require "spec_helper"
+
+describe PhlexyUI::Hero do
+  subject(:output) { render described_class.new }
+
+  it "is expected to match the formatted HTML" do
+    expected_html = html <<~HTML
+      <div class="hero"></div>
+    HTML
+
+    is_expected.to eq(expected_html)
+  end
+
+  describe "with part methods" do
+    subject(:output) do
+      render described_class.new do |h|
+        h.content { "Content" }
+        h.overlay { "Overlay" }
+      end
+    end
+
+    it "renders all parts" do
+      expected_html = html <<~HTML
+        <div class="hero">
+          <div class="hero-content">Content</div>
+          <div class="hero-overlay">Overlay</div>
+        </div>
+      HTML
+
+      expect(output).to eq(expected_html)
+    end
+  end
+
+  describe "data" do
+    subject(:output) do
+      render described_class.new(data: {foo: "bar"})
+    end
+
+    it "renders it correctly" do
+      expected_html = html <<~HTML
+        <div class="hero" data-foo="bar"></div>
+      HTML
+
+      expect(output).to eq(expected_html)
+    end
+  end
+
+  describe "passing :as option" do
+    subject(:output) { render described_class.new(as: :section) }
+
+    it "renders as the given tag" do
+      expected_html = html <<~HTML
+        <section class="hero"></section>
+      HTML
+
+      expect(output).to eq(expected_html)
+    end
+  end
+end


### PR DESCRIPTION
This PR adds the Hero component from #5.

## Changes
- Adds `PhlexyUI::Hero` component
- Includes comprehensive test coverage
- Follows PhlexyUI patterns and conventions

Part of breaking up #5 into individual component PRs.
