### PR TITLE
Add HoverGallery component

### DIFF
--- a/lib/phlexy_ui/hover_gallery.rb
+++ b/lib/phlexy_ui/hover_gallery.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module PhlexyUI
+  # @component html class="hover-gallery"
+  class HoverGallery < Base
+    def initialize(*, as: :figure, **)
+      super(*, **)
+      @as = as
+    end
+
+    def view_template(&)
+      generate_classes!(
+        # "hover-gallery"
+        component_html_class: :"hover-gallery",
+        modifiers_map: modifiers,
+        base_modifiers:,
+        options:
+      ).then do |classes|
+        public_send(as, class: classes, **options, &)
+      end
+    end
+  end
+end

--- a/spec/lib/phlexy_ui/hover_gallery_spec.rb
+++ b/spec/lib/phlexy_ui/hover_gallery_spec.rb
@@ -1,0 +1,39 @@
+require "spec_helper"
+
+describe PhlexyUI::HoverGallery do
+  subject(:output) { render described_class.new }
+
+  it "is expected to match the formatted HTML" do
+    expected_html = html <<~HTML
+      <figure class="hover-gallery"></figure>
+    HTML
+
+    is_expected.to eq(expected_html)
+  end
+
+  describe "data" do
+    subject(:output) do
+      render described_class.new(data: {foo: "bar"})
+    end
+
+    it "renders it correctly" do
+      expected_html = html <<~HTML
+        <figure class="hover-gallery" data-foo="bar"></figure>
+      HTML
+
+      expect(output).to eq(expected_html)
+    end
+  end
+
+  describe "passing :as option" do
+    subject(:output) { render described_class.new(as: :div) }
+
+    it "renders as the given tag" do
+      expected_html = html <<~HTML
+        <div class="hover-gallery"></div>
+      HTML
+
+      expect(output).to eq(expected_html)
+    end
+  end
+end


### PR DESCRIPTION
This PR adds the HoverGallery component from #5.

## Changes
- Adds `PhlexyUI::HoverGallery` component
- Includes comprehensive test coverage
- Follows PhlexyUI patterns and conventions

Part of breaking up #5 into individual component PRs.
