### PR TITLE
Add Input component

### DIFF
--- a/lib/phlexy_ui/input.rb
+++ b/lib/phlexy_ui/input.rb
@@ -1,0 +1,124 @@
+# frozen_string_literal: true
+
+module PhlexyUI
+  # @component html class="input"
+  class Input < Base
+    def initialize(*, as: :input, **)
+      super(*, **)
+      @as = as
+    end
+
+    def view_template(&)
+      generate_classes!(
+        # "input"
+        component_html_class: :input,
+        modifiers_map: modifiers,
+        base_modifiers:,
+        options:
+      ).then do |classes|
+        public_send(as, class: classes, **options, &)
+      end
+    end
+
+    register_modifiers(
+      # "sm:input-ghost"
+      # "@sm:input-ghost"
+      # "md:input-ghost"
+      # "@md:input-ghost"
+      # "lg:input-ghost"
+      # "@lg:input-ghost"
+      ghost: "input-ghost",
+      # "sm:input-xs"
+      # "@sm:input-xs"
+      # "md:input-xs"
+      # "@md:input-xs"
+      # "lg:input-xs"
+      # "@lg:input-xs"
+      xs: "input-xs",
+      # "sm:input-sm"
+      # "@sm:input-sm"
+      # "md:input-sm"
+      # "@md:input-sm"
+      # "lg:input-sm"
+      # "@lg:input-sm"
+      sm: "input-sm",
+      # "sm:input-md"
+      # "@sm:input-md"
+      # "md:input-md"
+      # "@md:input-md"
+      # "lg:input-md"
+      # "@lg:input-md"
+      md: "input-md",
+      # "sm:input-lg"
+      # "@sm:input-lg"
+      # "md:input-lg"
+      # "@md:input-lg"
+      # "lg:input-lg"
+      # "@lg:input-lg"
+      lg: "input-lg",
+      # "sm:input-xl"
+      # "@sm:input-xl"
+      # "md:input-xl"
+      # "@md:input-xl"
+      # "lg:input-xl"
+      # "@lg:input-xl"
+      xl: "input-xl",
+      # "sm:input-neutral"
+      # "@sm:input-neutral"
+      # "md:input-neutral"
+      # "@md:input-neutral"
+      # "lg:input-neutral"
+      # "@lg:input-neutral"
+      neutral: "input-neutral",
+      # "sm:input-primary"
+      # "@sm:input-primary"
+      # "md:input-primary"
+      # "@md:input-primary"
+      # "lg:input-primary"
+      # "@lg:input-primary"
+      primary: "input-primary",
+      # "sm:input-secondary"
+      # "@sm:input-secondary"
+      # "md:input-secondary"
+      # "@md:input-secondary"
+      # "lg:input-secondary"
+      # "@lg:input-secondary"
+      secondary: "input-secondary",
+      # "sm:input-accent"
+      # "@sm:input-accent"
+      # "md:input-accent"
+      # "@md:input-accent"
+      # "lg:input-accent"
+      # "@lg:input-accent"
+      accent: "input-accent",
+      # "sm:input-info"
+      # "@sm:input-info"
+      # "md:input-info"
+      # "@md:input-info"
+      # "lg:input-info"
+      # "@lg:input-info"
+      info: "input-info",
+      # "sm:input-success"
+      # "@sm:input-success"
+      # "md:input-success"
+      # "@md:input-success"
+      # "lg:input-success"
+      # "@lg:input-success"
+      success: "input-success",
+      # "sm:input-warning"
+      # "@sm:input-warning"
+      # "md:input-warning"
+      # "@md:input-warning"
+      # "lg:input-warning"
+      # "@lg:input-warning"
+      warning: "input-warning",
+      # "sm:input-error"
+      # "@sm:input-error"
+      # "md:input-error"
+      # "@md:input-error"
+      # "lg:input-error"
+      # "@lg:input-error"
+      error: "input-error"
+    )
+  end
+end

--- a/spec/lib/phlexy_ui/input_spec.rb
+++ b/spec/lib/phlexy_ui/input_spec.rb
@@ -1,0 +1,100 @@
+require "spec_helper"
+
+describe PhlexyUI::Input do
+  subject(:output) { render described_class.new }
+
+  it "is expected to match the formatted HTML" do
+    expected_html = html <<~HTML
+      <input class="input">
+    HTML
+
+    is_expected.to eq(expected_html)
+  end
+
+  describe "conditions" do
+    {
+      ghost: "input-ghost",
+      xs: "input-xs",
+      sm: "input-sm",
+      md: "input-md",
+      lg: "input-lg",
+      xl: "input-xl",
+      neutral: "input-neutral",
+      primary: "input-primary",
+      secondary: "input-secondary",
+      accent: "input-accent",
+      info: "input-info",
+      success: "input-success",
+      warning: "input-warning",
+      error: "input-error"
+    }.each do |modifier, css|
+      context "when given :#{modifier} modifier" do
+        subject(:output) { render described_class.new(modifier) }
+
+        it "renders it apart from the main class" do
+          expected_html = html <<~HTML
+            <input class="input #{css}">
+          HTML
+
+          expect(output).to eq(expected_html)
+        end
+      end
+    end
+
+    context "when given multiple conditions" do
+      subject(:output) { render described_class.new(:primary, :lg) }
+
+      it "renders them separately" do
+        expected_html = html <<~HTML
+          <input class="input input-primary input-lg">
+        HTML
+
+        expect(output).to eq(expected_html)
+      end
+    end
+  end
+
+  describe "data" do
+    subject(:output) do
+      render described_class.new(data: {foo: "bar"})
+    end
+
+    it "renders it correctly" do
+      expected_html = html <<~HTML
+        <input class="input" data-foo="bar">
+      HTML
+
+      expect(output).to eq(expected_html)
+    end
+  end
+
+  describe "responsiveness" do
+    %i[sm md lg xl @sm @md @lg @xl].each do |viewport|
+      context "when given an :#{viewport} responsive option" do
+        subject(:output) do
+          render described_class.new(:primary, responsive: {viewport => :secondary})
+        end
+
+        it "renders it separately with a responsive prefix" do
+          expected_html = html <<~HTML
+            <input class="input input-primary #{viewport}:input-secondary">
+          HTML
+
+          expect(output).to eq(expected_html)
+        end
+      end
+    end
+  end
+
+  describe "passing :as option" do
+    subject(:output) { render described_class.new(as: :textarea) }
+
+    it "renders as the given tag" do
+      expected_html = html <<~HTML
+        <textarea class="input"></textarea>
+      HTML
+
+      expect(output).to eq(expected_html)
+    end
+  end
+end


### PR DESCRIPTION
This PR adds the Input component from #5.

## Changes
- Adds `PhlexyUI::Input` component
- Includes comprehensive test coverage
- Follows PhlexyUI patterns and conventions

Part of breaking up #5 into individual component PRs.
