### PR TITLE
Add Join component

### DIFF
--- a/lib/phlexy_ui/join.rb
+++ b/lib/phlexy_ui/join.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 module PhlexyUI
-  # @component html class="join"
   class Join < Base
     def initialize(*, as: :div, **)
       super(*, **)

--- a/lib/phlexy_ui/join.rb
+++ b/lib/phlexy_ui/join.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+module PhlexyUI
+  # @component html class="join"
+  class Join < Base
+    def initialize(*, as: :div, **)
+      super(*, **)
+      @as = as
+    end
+
+    def view_template(&)
+      generate_classes!(
+        # "join"
+        component_html_class: :join,
+        modifiers_map: modifiers,
+        base_modifiers:,
+        options:
+      ).then do |classes|
+        public_send(as, class: classes, **options, &)
+      end
+    end
+
+    def item(**options, &)
+      generate_classes!(
+        # "join-item"
+        component_html_class: :"join-item",
+        options:
+      ).then do |classes|
+        div(class: classes, **options, &)
+      end
+    end
+
+    register_modifiers(
+      # "sm:join-vertical"
+      # "@sm:join-vertical"
+      # "md:join-vertical"
+      # "@md:join-vertical"
+      # "lg:join-vertical"
+      # "@lg:join-vertical"
+      vertical: "join-vertical",
+      # "sm:join-horizontal"
+      # "@sm:join-horizontal"
+      # "md:join-horizontal"
+      # "@md:join-horizontal"
+      # "lg:join-horizontal"
+      # "@lg:join-horizontal"
+      horizontal: "join-horizontal"
+    )
+  end
+end

--- a/spec/lib/phlexy_ui/join_spec.rb
+++ b/spec/lib/phlexy_ui/join_spec.rb
@@ -1,0 +1,96 @@
+require "spec_helper"
+
+describe PhlexyUI::Join do
+  subject(:output) { render described_class.new }
+
+  it "is expected to match the formatted HTML" do
+    expected_html = html <<~HTML
+      <div class="join"></div>
+    HTML
+
+    is_expected.to eq(expected_html)
+  end
+
+  describe "with item method" do
+    subject(:output) do
+      render described_class.new do |j|
+        j.item { "Item 1" }
+        j.item { "Item 2" }
+      end
+    end
+
+    it "renders items" do
+      expected_html = html <<~HTML
+        <div class="join">
+          <div class="join-item">Item 1</div>
+          <div class="join-item">Item 2</div>
+        </div>
+      HTML
+
+      expect(output).to eq(expected_html)
+    end
+  end
+
+  describe "conditions" do
+    {
+      vertical: "join-vertical",
+      horizontal: "join-horizontal"
+    }.each do |modifier, css|
+      context "when given :#{modifier} modifier" do
+        subject(:output) { render described_class.new(modifier) }
+
+        it "renders it apart from the main class" do
+          expected_html = html <<~HTML
+            <div class="join #{css}"></div>
+          HTML
+
+          expect(output).to eq(expected_html)
+        end
+      end
+    end
+  end
+
+  describe "data" do
+    subject(:output) do
+      render described_class.new(data: {foo: "bar"})
+    end
+
+    it "renders it correctly" do
+      expected_html = html <<~HTML
+        <div class="join" data-foo="bar"></div>
+      HTML
+
+      expect(output).to eq(expected_html)
+    end
+  end
+
+  describe "responsiveness" do
+    %i[sm md lg xl @sm @md @lg @xl].each do |viewport|
+      context "when given an :#{viewport} responsive option" do
+        subject(:output) do
+          render described_class.new(:vertical, responsive: {viewport => :horizontal})
+        end
+
+        it "renders it separately with a responsive prefix" do
+          expected_html = html <<~HTML
+            <div class="join join-vertical #{viewport}:join-horizontal"></div>
+          HTML
+
+          expect(output).to eq(expected_html)
+        end
+      end
+    end
+  end
+
+  describe "passing :as option" do
+    subject(:output) { render described_class.new(as: :section) }
+
+    it "renders as the given tag" do
+      expected_html = html <<~HTML
+        <section class="join"></section>
+      HTML
+
+      expect(output).to eq(expected_html)
+    end
+  end
+end


### PR DESCRIPTION
This PR adds the Join component from #5.

## Changes
- Adds `PhlexyUI::Join` component
- Includes comprehensive test coverage
- Follows PhlexyUI patterns and conventions

Part of breaking up #5 into individual component PRs.
