### PR TITLE
Add List component

### DIFF
--- a/lib/phlexy_ui/list.rb
+++ b/lib/phlexy_ui/list.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+module PhlexyUI
+  # @component html class="list"
+  class List < Base
+    def initialize(*, as: :ul, **)
+      super(*, **)
+      @as = as
+    end
+
+    def view_template(&)
+      generate_classes!(
+        # "list"
+        component_html_class: :list,
+        modifiers_map: modifiers,
+        base_modifiers:,
+        options:
+      ).then do |classes|
+        public_send(as, class: classes, **options, &)
+      end
+    end
+
+    def row(**options, &)
+      generate_classes!(
+        # "list-row"
+        component_html_class: :"list-row",
+        options:
+      ).then do |classes|
+        li(class: classes, **options, &)
+      end
+    end
+
+    register_modifiers(
+      # "sm:list-col-wrap"
+      # "@sm:list-col-wrap"
+      # "md:list-col-wrap"
+      # "@md:list-col-wrap"
+      # "lg:list-col-wrap"
+      # "@lg:list-col-wrap"
+      col_wrap: "list-col-wrap",
+      # "sm:list-col-grow"
+      # "@sm:list-col-grow"
+      # "md:list-col-grow"
+      # "@md:list-col-grow"
+      # "lg:list-col-grow"
+      # "@lg:list-col-grow"
+      col_grow: "list-col-grow"
+    )
+  end
+end

--- a/lib/phlexy_ui/list.rb
+++ b/lib/phlexy_ui/list.rb
@@ -30,21 +30,24 @@ module PhlexyUI
       end
     end
 
-    register_modifiers(
-      # "sm:list-col-wrap"
-      # "@sm:list-col-wrap"
-      # "md:list-col-wrap"
-      # "@md:list-col-wrap"
-      # "lg:list-col-wrap"
-      # "@lg:list-col-wrap"
-      col_wrap: "list-col-wrap",
-      # "sm:list-col-grow"
-      # "@sm:list-col-grow"
-      # "md:list-col-grow"
-      # "@md:list-col-grow"
-      # "lg:list-col-grow"
-      # "@lg:list-col-grow"
-      col_grow: "list-col-grow"
-    )
+    def col_wrap(as: :div, **options, &)
+      generate_classes!(
+        # "list-col-wrap"
+        component_html_class: :"list-col-wrap",
+        options:
+      ).then do |classes|
+        public_send(as, class: classes, **options, &)
+      end
+    end
+
+    def col_grow(as: :div, **options, &)
+      generate_classes!(
+        # "list-col-grow"
+        component_html_class: :"list-col-grow",
+        options:
+      ).then do |classes|
+        public_send(as, class: classes, **options, &)
+      end
+    end
   end
 end

--- a/spec/lib/phlexy_ui/list_spec.rb
+++ b/spec/lib/phlexy_ui/list_spec.rb
@@ -31,34 +31,69 @@ describe PhlexyUI::List do
     end
   end
 
-  describe "conditions" do
-    {
-      col_wrap: "list-col-wrap",
-      col_grow: "list-col-grow"
-    }.each do |modifier, css|
-      context "when given :#{modifier} modifier" do
-        subject(:output) { render described_class.new(modifier) }
-
-        it "renders it apart from the main class" do
-          expected_html = html <<~HTML
-            <ul class="list #{css}"></ul>
-          HTML
-
-          expect(output).to eq(expected_html)
+  describe "with col_wrap method" do
+    subject(:output) do
+      render described_class.new do |l|
+        l.row do
+          l.col_wrap { "Wrapping content" }
         end
       end
     end
 
-    context "when given multiple conditions" do
-      subject(:output) { render described_class.new(:col_wrap, :col_grow) }
+    it "renders col_wrap inside row" do
+      expected_html = html <<~HTML
+        <ul class="list">
+          <li class="list-row">
+            <div class="list-col-wrap">Wrapping content</div>
+          </li>
+        </ul>
+      HTML
 
-      it "renders them separately" do
-        expected_html = html <<~HTML
-          <ul class="list list-col-wrap list-col-grow"></ul>
-        HTML
+      expect(output).to eq(expected_html)
+    end
+  end
 
-        expect(output).to eq(expected_html)
+  describe "with col_grow method" do
+    subject(:output) do
+      render described_class.new do |l|
+        l.row do
+          l.col_grow { "Growing content" }
+        end
       end
+    end
+
+    it "renders col_grow inside row" do
+      expected_html = html <<~HTML
+        <ul class="list">
+          <li class="list-row">
+            <div class="list-col-grow">Growing content</div>
+          </li>
+        </ul>
+      HTML
+
+      expect(output).to eq(expected_html)
+    end
+  end
+
+  describe "with col_grow custom element" do
+    subject(:output) do
+      render described_class.new do |l|
+        l.row do
+          l.col_grow(as: :span) { "Growing content" }
+        end
+      end
+    end
+
+    it "renders col_grow as specified element" do
+      expected_html = html <<~HTML
+        <ul class="list">
+          <li class="list-row">
+            <span class="list-col-grow">Growing content</span>
+          </li>
+        </ul>
+      HTML
+
+      expect(output).to eq(expected_html)
     end
   end
 
@@ -76,21 +111,27 @@ describe PhlexyUI::List do
     end
   end
 
-  describe "responsiveness" do
-    %i[sm md lg xl @sm @md @lg @xl].each do |viewport|
-      context "when given an :#{viewport} responsive option" do
-        subject(:output) do
-          render described_class.new(:col_wrap, responsive: {viewport => :col_grow})
-        end
-
-        it "renders it separately with a responsive prefix" do
-          expected_html = html <<~HTML
-            <ul class="list list-col-wrap #{viewport}:list-col-grow"></ul>
-          HTML
-
-          expect(output).to eq(expected_html)
+  describe "with both col_wrap and col_grow in same row" do
+    subject(:output) do
+      render described_class.new do |l|
+        l.row do
+          l.col_grow { "Growing content" }
+          l.col_wrap { "Wrapping content" }
         end
       end
+    end
+
+    it "renders both column types in one row" do
+      expected_html = html <<~HTML
+        <ul class="list">
+          <li class="list-row">
+            <div class="list-col-grow">Growing content</div>
+            <div class="list-col-wrap">Wrapping content</div>
+          </li>
+        </ul>
+      HTML
+
+      expect(output).to eq(expected_html)
     end
   end
 

--- a/spec/lib/phlexy_ui/list_spec.rb
+++ b/spec/lib/phlexy_ui/list_spec.rb
@@ -1,0 +1,108 @@
+require "spec_helper"
+
+describe PhlexyUI::List do
+  subject(:output) { render described_class.new }
+
+  it "is expected to match the formatted HTML" do
+    expected_html = html <<~HTML
+      <ul class="list"></ul>
+    HTML
+
+    is_expected.to eq(expected_html)
+  end
+
+  describe "with row method" do
+    subject(:output) do
+      render described_class.new do |l|
+        l.row { "Row 1" }
+        l.row { "Row 2" }
+      end
+    end
+
+    it "renders rows" do
+      expected_html = html <<~HTML
+        <ul class="list">
+          <li class="list-row">Row 1</li>
+          <li class="list-row">Row 2</li>
+        </ul>
+      HTML
+
+      expect(output).to eq(expected_html)
+    end
+  end
+
+  describe "conditions" do
+    {
+      col_wrap: "list-col-wrap",
+      col_grow: "list-col-grow"
+    }.each do |modifier, css|
+      context "when given :#{modifier} modifier" do
+        subject(:output) { render described_class.new(modifier) }
+
+        it "renders it apart from the main class" do
+          expected_html = html <<~HTML
+            <ul class="list #{css}"></ul>
+          HTML
+
+          expect(output).to eq(expected_html)
+        end
+      end
+    end
+
+    context "when given multiple conditions" do
+      subject(:output) { render described_class.new(:col_wrap, :col_grow) }
+
+      it "renders them separately" do
+        expected_html = html <<~HTML
+          <ul class="list list-col-wrap list-col-grow"></ul>
+        HTML
+
+        expect(output).to eq(expected_html)
+      end
+    end
+  end
+
+  describe "data" do
+    subject(:output) do
+      render described_class.new(data: {foo: "bar"})
+    end
+
+    it "renders it correctly" do
+      expected_html = html <<~HTML
+        <ul class="list" data-foo="bar"></ul>
+      HTML
+
+      expect(output).to eq(expected_html)
+    end
+  end
+
+  describe "responsiveness" do
+    %i[sm md lg xl @sm @md @lg @xl].each do |viewport|
+      context "when given an :#{viewport} responsive option" do
+        subject(:output) do
+          render described_class.new(:col_wrap, responsive: {viewport => :col_grow})
+        end
+
+        it "renders it separately with a responsive prefix" do
+          expected_html = html <<~HTML
+            <ul class="list list-col-wrap #{viewport}:list-col-grow"></ul>
+          HTML
+
+          expect(output).to eq(expected_html)
+        end
+      end
+    end
+  end
+
+  describe "passing :as option" do
+    subject(:output) { render described_class.new(as: :ol) }
+
+    it "renders as the given tag" do
+      expected_html = html <<~HTML
+        <ol class="list"></ol>
+      HTML
+
+      expect(output).to eq(expected_html)
+    end
+  end
+end


### PR DESCRIPTION
This PR adds the List component from #5.

## Changes
- Adds `PhlexyUI::List` component
- Includes comprehensive test coverage
- Follows PhlexyUI patterns and conventions

Part of breaking up #5 into individual component PRs.
