### PR TITLE
Add Progress component

### DIFF
--- a/lib/phlexy_ui/progress.rb
+++ b/lib/phlexy_ui/progress.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+module PhlexyUI
+  # @component html class="progress"
+  class Progress < Base
+    def initialize(*, as: :progress, **)
+      super(*, **)
+      @as = as
+    end
+
+    def view_template(&)
+      generate_classes!(
+        # "progress"
+        component_html_class: :progress,
+        modifiers_map: modifiers,
+        base_modifiers:,
+        options:
+      ).then do |classes|
+        public_send(as, class: classes, **options, &)
+      end
+    end
+
+    register_modifiers(
+      # "sm:progress-neutral"
+      # "@sm:progress-neutral"
+      # "md:progress-neutral"
+      # "@md:progress-neutral"
+      # "lg:progress-neutral"
+      # "@lg:progress-neutral"
+      neutral: "progress-neutral",
+      # "sm:progress-primary"
+      # "@sm:progress-primary"
+      # "md:progress-primary"
+      # "@md:progress-primary"
+      # "lg:progress-primary"
+      # "@lg:progress-primary"
+      primary: "progress-primary",
+      # "sm:progress-secondary"
+      # "@sm:progress-secondary"
+      # "md:progress-secondary"
+      # "@md:progress-secondary"
+      # "lg:progress-secondary"
+      # "@lg:progress-secondary"
+      secondary: "progress-secondary",
+      # "sm:progress-accent"
+      # "@sm:progress-accent"
+      # "md:progress-accent"
+      # "@md:progress-accent"
+      # "lg:progress-accent"
+      # "@lg:progress-accent"
+      accent: "progress-accent",
+      # "sm:progress-info"
+      # "@sm:progress-info"
+      # "md:progress-info"
+      # "@md:progress-info"
+      # "lg:progress-info"
+      # "@lg:progress-info"
+      info: "progress-info",
+      # "sm:progress-success"
+      # "@sm:progress-success"
+      # "md:progress-success"
+      # "@md:progress-success"
+      # "lg:progress-success"
+      # "@lg:progress-success"
+      success: "progress-success",
+      # "sm:progress-warning"
+      # "@sm:progress-warning"
+      # "md:progress-warning"
+      # "@md:progress-warning"
+      # "lg:progress-warning"
+      # "@lg:progress-warning"
+      warning: "progress-warning",
+      # "sm:progress-error"
+      # "@sm:progress-error"
+      # "md:progress-error"
+      # "@md:progress-error"
+      # "lg:progress-error"
+      # "@lg:progress-error"
+      error: "progress-error"
+    )
+  end
+end

--- a/spec/lib/phlexy_ui/progress_spec.rb
+++ b/spec/lib/phlexy_ui/progress_spec.rb
@@ -1,0 +1,94 @@
+require "spec_helper"
+
+describe PhlexyUI::Progress do
+  subject(:output) { render described_class.new }
+
+  it "is expected to match the formatted HTML" do
+    expected_html = html <<~HTML
+      <progress class="progress"></progress>
+    HTML
+
+    is_expected.to eq(expected_html)
+  end
+
+  describe "conditions" do
+    {
+      neutral: "progress-neutral",
+      primary: "progress-primary",
+      secondary: "progress-secondary",
+      accent: "progress-accent",
+      info: "progress-info",
+      success: "progress-success",
+      warning: "progress-warning",
+      error: "progress-error"
+    }.each do |modifier, css|
+      context "when given :#{modifier} modifier" do
+        subject(:output) { render described_class.new(modifier) }
+
+        it "renders it apart from the main class" do
+          expected_html = html <<~HTML
+            <progress class="progress #{css}"></progress>
+          HTML
+
+          expect(output).to eq(expected_html)
+        end
+      end
+    end
+
+    context "when given multiple conditions" do
+      subject(:output) { render described_class.new(:primary, :neutral) }
+
+      it "renders them separately" do
+        expected_html = html <<~HTML
+          <progress class="progress progress-primary progress-neutral"></progress>
+        HTML
+
+        expect(output).to eq(expected_html)
+      end
+    end
+  end
+
+  describe "data" do
+    subject(:output) do
+      render described_class.new(data: {foo: "bar"})
+    end
+
+    it "renders it correctly" do
+      expected_html = html <<~HTML
+        <progress class="progress" data-foo="bar"></progress>
+      HTML
+
+      expect(output).to eq(expected_html)
+    end
+  end
+
+  describe "responsiveness" do
+    %i[sm md lg xl @sm @md @lg @xl].each do |viewport|
+      context "when given an :#{viewport} responsive option" do
+        subject(:output) do
+          render described_class.new(:primary, responsive: {viewport => :secondary})
+        end
+
+        it "renders it separately with a responsive prefix" do
+          expected_html = html <<~HTML
+            <progress class="progress progress-primary #{viewport}:progress-secondary"></progress>
+          HTML
+
+          expect(output).to eq(expected_html)
+        end
+      end
+    end
+  end
+
+  describe "passing :as option" do
+    subject(:output) { render described_class.new(as: :div) }
+
+    it "renders as the given tag" do
+      expected_html = html <<~HTML
+        <div class="progress"></div>
+      HTML
+
+      expect(output).to eq(expected_html)
+    end
+  end
+end


### PR DESCRIPTION
This PR adds the Progress component from #5.

## Changes
- Adds `PhlexyUI::Progress` component
- Includes comprehensive test coverage
- Follows PhlexyUI patterns and conventions

Part of breaking up #5 into individual component PRs.
