### PR TITLE
Add Radio component

### DIFF
--- a/lib/phlexy_ui/radio.rb
+++ b/lib/phlexy_ui/radio.rb
@@ -1,0 +1,117 @@
+# frozen_string_literal: true
+
+module PhlexyUI
+  # @component html class="radio"
+  class Radio < Base
+    def initialize(*, as: :input, **)
+      super(*, **)
+      @as = as
+    end
+
+    def view_template(&)
+      generate_classes!(
+        # "radio"
+        component_html_class: :radio,
+        modifiers_map: modifiers,
+        base_modifiers:,
+        options:
+      ).then do |classes|
+        public_send(as, type: :radio, class: classes, **options, &)
+      end
+    end
+
+    register_modifiers(
+      # "sm:radio-xs"
+      # "@sm:radio-xs"
+      # "md:radio-xs"
+      # "@md:radio-xs"
+      # "lg:radio-xs"
+      # "@lg:radio-xs"
+      xs: "radio-xs",
+      # "sm:radio-sm"
+      # "@sm:radio-sm"
+      # "md:radio-sm"
+      # "@md:radio-sm"
+      # "lg:radio-sm"
+      # "@lg:radio-sm"
+      sm: "radio-sm",
+      # "sm:radio-md"
+      # "@sm:radio-md"
+      # "md:radio-md"
+      # "@md:radio-md"
+      # "lg:radio-md"
+      # "@lg:radio-md"
+      md: "radio-md",
+      # "sm:radio-lg"
+      # "@sm:radio-lg"
+      # "md:radio-lg"
+      # "@md:radio-lg"
+      # "lg:radio-lg"
+      # "@lg:radio-lg"
+      lg: "radio-lg",
+      # "sm:radio-xl"
+      # "@sm:radio-xl"
+      # "md:radio-xl"
+      # "@md:radio-xl"
+      # "lg:radio-xl"
+      # "@lg:radio-xl"
+      xl: "radio-xl",
+      # "sm:radio-neutral"
+      # "@sm:radio-neutral"
+      # "md:radio-neutral"
+      # "@md:radio-neutral"
+      # "lg:radio-neutral"
+      # "@lg:radio-neutral"
+      neutral: "radio-neutral",
+      # "sm:radio-primary"
+      # "@sm:radio-primary"
+      # "md:radio-primary"
+      # "@md:radio-primary"
+      # "lg:radio-primary"
+      # "@lg:radio-primary"
+      primary: "radio-primary",
+      # "sm:radio-secondary"
+      # "@sm:radio-secondary"
+      # "md:radio-secondary"
+      # "@md:radio-secondary"
+      # "lg:radio-secondary"
+      # "@lg:radio-secondary"
+      secondary: "radio-secondary",
+      # "sm:radio-accent"
+      # "@sm:radio-accent"
+      # "md:radio-accent"
+      # "@md:radio-accent"
+      # "lg:radio-accent"
+      # "@lg:radio-accent"
+      accent: "radio-accent",
+      # "sm:radio-success"
+      # "@sm:radio-success"
+      # "md:radio-success"
+      # "@md:radio-success"
+      # "lg:radio-success"
+      # "@lg:radio-success"
+      success: "radio-success",
+      # "sm:radio-warning"
+      # "@sm:radio-warning"
+      # "md:radio-warning"
+      # "@md:radio-warning"
+      # "lg:radio-warning"
+      # "@lg:radio-warning"
+      warning: "radio-warning",
+      # "sm:radio-info"
+      # "@sm:radio-info"
+      # "md:radio-info"
+      # "@md:radio-info"
+      # "lg:radio-info"
+      # "@lg:radio-info"
+      info: "radio-info",
+      # "sm:radio-error"
+      # "@sm:radio-error"
+      # "md:radio-error"
+      # "@md:radio-error"
+      # "lg:radio-error"
+      # "@lg:radio-error"
+      error: "radio-error"
+    )
+  end
+end

--- a/spec/lib/phlexy_ui/radio_spec.rb
+++ b/spec/lib/phlexy_ui/radio_spec.rb
@@ -1,0 +1,99 @@
+require "spec_helper"
+
+describe PhlexyUI::Radio do
+  subject(:output) { render described_class.new }
+
+  it "is expected to match the formatted HTML" do
+    expected_html = html <<~HTML
+      <input type="radio" class="radio">
+    HTML
+
+    is_expected.to eq(expected_html)
+  end
+
+  describe "conditions" do
+    {
+      xs: "radio-xs",
+      sm: "radio-sm",
+      md: "radio-md",
+      lg: "radio-lg",
+      xl: "radio-xl",
+      neutral: "radio-neutral",
+      primary: "radio-primary",
+      secondary: "radio-secondary",
+      accent: "radio-accent",
+      success: "radio-success",
+      warning: "radio-warning",
+      info: "radio-info",
+      error: "radio-error"
+    }.each do |modifier, css|
+      context "when given :#{modifier} modifier" do
+        subject(:output) { render described_class.new(modifier) }
+
+        it "renders it apart from the main class" do
+          expected_html = html <<~HTML
+            <input type="radio" class="radio #{css}">
+          HTML
+
+          expect(output).to eq(expected_html)
+        end
+      end
+    end
+
+    context "when given multiple conditions" do
+      subject(:output) { render described_class.new(:primary, :lg) }
+
+      it "renders them separately" do
+        expected_html = html <<~HTML
+          <input type="radio" class="radio radio-primary radio-lg">
+        HTML
+
+        expect(output).to eq(expected_html)
+      end
+    end
+  end
+
+  describe "data" do
+    subject(:output) do
+      render described_class.new(data: {foo: "bar"})
+    end
+
+    it "renders it correctly" do
+      expected_html = html <<~HTML
+        <input type="radio" class="radio" data-foo="bar">
+      HTML
+
+      expect(output).to eq(expected_html)
+    end
+  end
+
+  describe "responsiveness" do
+    %i[sm md lg xl @sm @md @lg @xl].each do |viewport|
+      context "when given an :#{viewport} responsive option" do
+        subject(:output) do
+          render described_class.new(:primary, responsive: {viewport => :secondary})
+        end
+
+        it "renders it separately with a responsive prefix" do
+          expected_html = html <<~HTML
+            <input type="radio" class="radio radio-primary #{viewport}:radio-secondary">
+          HTML
+
+          expect(output).to eq(expected_html)
+        end
+      end
+    end
+  end
+
+  describe "passing :as option" do
+    subject(:output) { render described_class.new(as: :div) }
+
+    it "renders as the given tag" do
+      expected_html = html <<~HTML
+        <div type="radio" class="radio"></div>
+      HTML
+
+      expect(output).to eq(expected_html)
+    end
+  end
+end


### PR DESCRIPTION
This PR adds the Radio component from #5.

## Changes
- Adds `PhlexyUI::Radio` component
- Includes comprehensive test coverage
- Follows PhlexyUI patterns and conventions

Part of breaking up #5 into individual component PRs.
