### PR TITLE
Add Rating component

### DIFF
--- a/lib/phlexy_ui/rating.rb
+++ b/lib/phlexy_ui/rating.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+module PhlexyUI
+  # @component html class="rating"
+  class Rating < Base
+    def initialize(*, as: :div, **)
+      super(*, **)
+      @as = as
+    end
+
+    def view_template(&)
+      generate_classes!(
+        # "rating"
+        component_html_class: :rating,
+        modifiers_map: modifiers,
+        base_modifiers:,
+        options:
+      ).then do |classes|
+        public_send(as, class: classes, **options, &)
+      end
+    end
+
+    register_modifiers(
+      # "sm:rating-half"
+      # "@sm:rating-half"
+      # "md:rating-half"
+      # "@md:rating-half"
+      # "lg:rating-half"
+      # "@lg:rating-half"
+      half: "rating-half",
+      # "sm:rating-hidden"
+      # "@sm:rating-hidden"
+      # "md:rating-hidden"
+      # "@md:rating-hidden"
+      # "lg:rating-hidden"
+      # "@lg:rating-hidden"
+      hidden: "rating-hidden",
+      # "sm:rating-xs"
+      # "@sm:rating-xs"
+      # "md:rating-xs"
+      # "@md:rating-xs"
+      # "lg:rating-xs"
+      # "@lg:rating-xs"
+      xs: "rating-xs",
+      # "sm:rating-sm"
+      # "@sm:rating-sm"
+      # "md:rating-sm"
+      # "@md:rating-sm"
+      # "lg:rating-sm"
+      # "@lg:rating-sm"
+      sm: "rating-sm",
+      # "sm:rating-md"
+      # "@sm:rating-md"
+      # "md:rating-md"
+      # "@md:rating-md"
+      # "lg:rating-md"
+      # "@lg:rating-md"
+      md: "rating-md",
+      # "sm:rating-lg"
+      # "@sm:rating-lg"
+      # "md:rating-lg"
+      # "@md:rating-lg"
+      # "lg:rating-lg"
+      # "@lg:rating-lg"
+      lg: "rating-lg",
+      # "sm:rating-xl"
+      # "@sm:rating-xl"
+      # "md:rating-xl"
+      # "@md:rating-xl"
+      # "lg:rating-xl"
+      # "@lg:rating-xl"
+      xl: "rating-xl"
+    )
+  end
+end

--- a/spec/lib/phlexy_ui/rating_spec.rb
+++ b/spec/lib/phlexy_ui/rating_spec.rb
@@ -1,0 +1,93 @@
+require "spec_helper"
+
+describe PhlexyUI::Rating do
+  subject(:output) { render described_class.new }
+
+  it "is expected to match the formatted HTML" do
+    expected_html = html <<~HTML
+      <div class="rating"></div>
+    HTML
+
+    is_expected.to eq(expected_html)
+  end
+
+  describe "conditions" do
+    {
+      half: "rating-half",
+      hidden: "rating-hidden",
+      xs: "rating-xs",
+      sm: "rating-sm",
+      md: "rating-md",
+      lg: "rating-lg",
+      xl: "rating-xl"
+    }.each do |modifier, css|
+      context "when given :#{modifier} modifier" do
+        subject(:output) { render described_class.new(modifier) }
+
+        it "renders it apart from the main class" do
+          expected_html = html <<~HTML
+            <div class="rating #{css}"></div>
+          HTML
+
+          expect(output).to eq(expected_html)
+        end
+      end
+    end
+
+    context "when given multiple conditions" do
+      subject(:output) { render described_class.new(:half, :lg) }
+
+      it "renders them separately" do
+        expected_html = html <<~HTML
+          <div class="rating rating-half rating-lg"></div>
+        HTML
+
+        expect(output).to eq(expected_html)
+      end
+    end
+  end
+
+  describe "data" do
+    subject(:output) do
+      render described_class.new(data: {foo: "bar"})
+    end
+
+    it "renders it correctly" do
+      expected_html = html <<~HTML
+        <div class="rating" data-foo="bar"></div>
+      HTML
+
+      expect(output).to eq(expected_html)
+    end
+  end
+
+  describe "responsiveness" do
+    %i[sm md lg xl @sm @md @lg @xl].each do |viewport|
+      context "when given an :#{viewport} responsive option" do
+        subject(:output) do
+          render described_class.new(:sm, responsive: {viewport => :lg})
+        end
+
+        it "renders it separately with a responsive prefix" do
+          expected_html = html <<~HTML
+            <div class="rating rating-sm #{viewport}:rating-lg"></div>
+          HTML
+
+          expect(output).to eq(expected_html)
+        end
+      end
+    end
+  end
+
+  describe "passing :as option" do
+    subject(:output) { render described_class.new(as: :span) }
+
+    it "renders as the given tag" do
+      expected_html = html <<~HTML
+        <span class="rating"></span>
+      HTML
+
+      expect(output).to eq(expected_html)
+    end
+  end
+end


### PR DESCRIPTION
This PR adds the Rating component from #5.

## Changes
- Adds `PhlexyUI::Rating` component
- Includes comprehensive test coverage
- Follows PhlexyUI patterns and conventions

Part of breaking up #5 into individual component PRs.
