### PR TITLE
Add Stack component

### DIFF
--- a/lib/phlexy_ui/stack.rb
+++ b/lib/phlexy_ui/stack.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+module PhlexyUI
+  # @component html class="stack"
+  class Stack < Base
+    def initialize(*, as: :div, **)
+      super(*, **)
+      @as = as
+    end
+
+    def view_template(&)
+      generate_classes!(
+        # "stack"
+        component_html_class: :stack,
+        modifiers_map: modifiers,
+        base_modifiers:,
+        options:
+      ).then do |classes|
+        public_send(as, class: classes, **options, &)
+      end
+    end
+
+    register_modifiers(
+      # "sm:stack-top"
+      # "@sm:stack-top"
+      # "md:stack-top"
+      # "@md:stack-top"
+      # "lg:stack-top"
+      # "@lg:stack-top"
+      top: "stack-top",
+      # "sm:stack-bottom"
+      # "@sm:stack-bottom"
+      # "md:stack-bottom"
+      # "@md:stack-bottom"
+      # "lg:stack-bottom"
+      # "@lg:stack-bottom"
+      bottom: "stack-bottom",
+      # "sm:stack-start"
+      # "@sm:stack-start"
+      # "md:stack-start"
+      # "@md:stack-start"
+      # "lg:stack-start"
+      # "@lg:stack-start"
+      start: "stack-start",
+        # "sm:stack-end"
+        # "@sm:stack-end"
+        # "md:stack-end"
+        # "@md:stack-end"
+        # "lg:stack-end"
+        # "@lg:stack-end"
+      end: "stack-end"
+    )
+  end
+end

--- a/spec/lib/phlexy_ui/stack_spec.rb
+++ b/spec/lib/phlexy_ui/stack_spec.rb
@@ -1,0 +1,90 @@
+require "spec_helper"
+
+describe PhlexyUI::Stack do
+  subject(:output) { render described_class.new }
+
+  it "is expected to match the formatted HTML" do
+    expected_html = html <<~HTML
+      <div class="stack"></div>
+    HTML
+
+    is_expected.to eq(expected_html)
+  end
+
+  describe "conditions" do
+    {
+      top: "stack-top",
+      bottom: "stack-bottom",
+      start: "stack-start",
+      end: "stack-end"
+    }.each do |modifier, css|
+      context "when given :#{modifier} modifier" do
+        subject(:output) { render described_class.new(modifier) }
+
+        it "renders it apart from the main class" do
+          expected_html = html <<~HTML
+            <div class="stack #{css}"></div>
+          HTML
+
+          expect(output).to eq(expected_html)
+        end
+      end
+    end
+
+    context "when given multiple conditions" do
+      subject(:output) { render described_class.new(:top, :end) }
+
+      it "renders them separately" do
+        expected_html = html <<~HTML
+          <div class="stack stack-top stack-end"></div>
+        HTML
+
+        expect(output).to eq(expected_html)
+      end
+    end
+  end
+
+  describe "data" do
+    subject(:output) do
+      render described_class.new(data: {foo: "bar"})
+    end
+
+    it "renders it correctly" do
+      expected_html = html <<~HTML
+        <div class="stack" data-foo="bar"></div>
+      HTML
+
+      expect(output).to eq(expected_html)
+    end
+  end
+
+  describe "responsiveness" do
+    %i[sm md lg xl @sm @md @lg @xl].each do |viewport|
+      context "when given an :#{viewport} responsive option" do
+        subject(:output) do
+          render described_class.new(:top, responsive: {viewport => :bottom})
+        end
+
+        it "renders it separately with a responsive prefix" do
+          expected_html = html <<~HTML
+            <div class="stack stack-top #{viewport}:stack-bottom"></div>
+          HTML
+
+          expect(output).to eq(expected_html)
+        end
+      end
+    end
+  end
+
+  describe "passing :as option" do
+    subject(:output) { render described_class.new(as: :section) }
+
+    it "renders as the given tag" do
+      expected_html = html <<~HTML
+        <section class="stack"></section>
+      HTML
+
+      expect(output).to eq(expected_html)
+    end
+  end
+end


### PR DESCRIPTION
This PR adds the Stack component from #5.

## Changes
- Adds `PhlexyUI::Stack` component
- Includes comprehensive test coverage
- Follows PhlexyUI patterns and conventions

Part of breaking up #5 into individual component PRs.
