### PR TITLE
Add Stat component

### DIFF
--- a/lib/phlexy_ui/stat.rb
+++ b/lib/phlexy_ui/stat.rb
@@ -1,0 +1,100 @@
+# frozen_string_literal: true
+
+module PhlexyUI
+  # @component html class="stats"
+  class Stat < Base
+    def initialize(*, as: :div, **)
+      super(*, **)
+      @as = as
+    end
+
+    def view_template(&)
+      generate_classes!(
+        # "stats"
+        component_html_class: :stats,
+        modifiers_map: modifiers,
+        base_modifiers:,
+        options:
+      ).then do |classes|
+        public_send(as, class: classes, **options, &)
+      end
+    end
+
+    def item(**options, &)
+      generate_classes!(
+        # "stat"
+        component_html_class: :stat,
+        options:
+      ).then do |classes|
+        div(class: classes, **options, &)
+      end
+    end
+
+    def title(**options, &)
+      generate_classes!(
+        # "stat-title"
+        component_html_class: :"stat-title",
+        options:
+      ).then do |classes|
+        div(class: classes, **options, &)
+      end
+    end
+
+    def value(**options, &)
+      generate_classes!(
+        # "stat-value"
+        component_html_class: :"stat-value",
+        options:
+      ).then do |classes|
+        div(class: classes, **options, &)
+      end
+    end
+
+    def desc(**options, &)
+      generate_classes!(
+        # "stat-desc"
+        component_html_class: :"stat-desc",
+        options:
+      ).then do |classes|
+        div(class: classes, **options, &)
+      end
+    end
+
+    def figure(**options, &)
+      generate_classes!(
+        # "stat-figure"
+        component_html_class: :"stat-figure",
+        options:
+      ).then do |classes|
+        div(class: classes, **options, &)
+      end
+    end
+
+    def actions(**options, &)
+      generate_classes!(
+        # "stat-actions"
+        component_html_class: :"stat-actions",
+        options:
+      ).then do |classes|
+        div(class: classes, **options, &)
+      end
+    end
+
+    register_modifiers(
+      # "sm:stats-horizontal"
+      # "@sm:stats-horizontal"
+      # "md:stats-horizontal"
+      # "@md:stats-horizontal"
+      # "lg:stats-horizontal"
+      # "@lg:stats-horizontal"
+      horizontal: "stats-horizontal",
+      # "sm:stats-vertical"
+      # "@sm:stats-vertical"
+      # "md:stats-vertical"
+      # "@md:stats-vertical"
+      # "lg:stats-vertical"
+      # "@lg:stats-vertical"
+      vertical: "stats-vertical"
+    )
+  end
+end

--- a/spec/lib/phlexy_ui/stat_spec.rb
+++ b/spec/lib/phlexy_ui/stat_spec.rb
@@ -1,0 +1,106 @@
+require "spec_helper"
+
+describe PhlexyUI::Stat do
+  subject(:output) { render described_class.new }
+
+  it "is expected to match the formatted HTML" do
+    expected_html = html <<~HTML
+      <div class="stats"></div>
+    HTML
+
+    is_expected.to eq(expected_html)
+  end
+
+  describe "with part methods" do
+    subject(:output) do
+      render described_class.new do |s|
+        s.item do
+          s.title { "Title" }
+          s.value { "Value" }
+          s.desc { "Description" }
+          s.figure { "Figure" }
+          s.actions { "Actions" }
+        end
+      end
+    end
+
+    it "renders all parts" do
+      expected_html = html <<~HTML
+        <div class="stats">
+          <div class="stat">
+            <div class="stat-title">Title</div>
+            <div class="stat-value">Value</div>
+            <div class="stat-desc">Description</div>
+            <div class="stat-figure">Figure</div>
+            <div class="stat-actions">Actions</div>
+          </div>
+        </div>
+      HTML
+
+      expect(output).to eq(expected_html)
+    end
+  end
+
+  describe "conditions" do
+    {
+      horizontal: "stats-horizontal",
+      vertical: "stats-vertical"
+    }.each do |modifier, css|
+      context "when given :#{modifier} modifier" do
+        subject(:output) { render described_class.new(modifier) }
+
+        it "renders it apart from the main class" do
+          expected_html = html <<~HTML
+            <div class="stats #{css}"></div>
+          HTML
+
+          expect(output).to eq(expected_html)
+        end
+      end
+    end
+  end
+
+  describe "data" do
+    subject(:output) do
+      render described_class.new(data: {foo: "bar"})
+    end
+
+    it "renders it correctly" do
+      expected_html = html <<~HTML
+        <div class="stats" data-foo="bar"></div>
+      HTML
+
+      expect(output).to eq(expected_html)
+    end
+  end
+
+  describe "responsiveness" do
+    %i[sm md lg xl @sm @md @lg @xl].each do |viewport|
+      context "when given an :#{viewport} responsive option" do
+        subject(:output) do
+          render described_class.new(:horizontal, responsive: {viewport => :vertical})
+        end
+
+        it "renders it separately with a responsive prefix" do
+          expected_html = html <<~HTML
+            <div class="stats stats-horizontal #{viewport}:stats-vertical"></div>
+          HTML
+
+          expect(output).to eq(expected_html)
+        end
+      end
+    end
+  end
+
+  describe "passing :as option" do
+    subject(:output) { render described_class.new(as: :section) }
+
+    it "renders as the given tag" do
+      expected_html = html <<~HTML
+        <section class="stats"></section>
+      HTML
+
+      expect(output).to eq(expected_html)
+    end
+  end
+end


### PR DESCRIPTION
This PR adds the Stat component from #5.

## Changes
- Adds `PhlexyUI::Stat` component
- Includes comprehensive test coverage
- Follows PhlexyUI patterns and conventions

Part of breaking up #5 into individual component PRs.
