### PR TITLE
Add Swap component

### DIFF
--- a/lib/phlexy_ui/swap.rb
+++ b/lib/phlexy_ui/swap.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+module PhlexyUI
+  # @component html class="swap"
+  class Swap < Base
+    def initialize(*, as: :label, **)
+      super(*, **)
+      @as = as
+    end
+
+    def view_template(&)
+      generate_classes!(
+        # "swap"
+        component_html_class: :swap,
+        modifiers_map: modifiers,
+        base_modifiers:,
+        options:
+      ).then do |classes|
+        public_send(as, class: classes, **options, &)
+      end
+    end
+
+    def on(**options, &)
+      generate_classes!(
+        # "swap-on"
+        component_html_class: :"swap-on",
+        options:
+      ).then do |classes|
+        div(class: classes, **options, &)
+      end
+    end
+
+    def off(**options, &)
+      generate_classes!(
+        # "swap-off"
+        component_html_class: :"swap-off",
+        options:
+      ).then do |classes|
+        div(class: classes, **options, &)
+      end
+    end
+
+    def indeterminate(**options, &)
+      generate_classes!(
+        # "swap-indeterminate"
+        component_html_class: :"swap-indeterminate",
+        options:
+      ).then do |classes|
+        div(class: classes, **options, &)
+      end
+    end
+
+    register_modifiers(
+      # "sm:swap-active"
+      # "@sm:swap-active"
+      # "md:swap-active"
+      # "@md:swap-active"
+      # "lg:swap-active"
+      # "@lg:swap-active"
+      active: "swap-active",
+      # "sm:swap-rotate"
+      # "@sm:swap-rotate"
+      # "md:swap-rotate"
+      # "@md:swap-rotate"
+      # "lg:swap-rotate"
+      # "@lg:swap-rotate"
+      rotate: "swap-rotate",
+      # "sm:swap-flip"
+      # "@sm:swap-flip"
+      # "md:swap-flip"
+      # "@md:swap-flip"
+      # "lg:swap-flip"
+      # "@lg:swap-flip"
+      flip: "swap-flip"
+    )
+  end
+end

--- a/spec/lib/phlexy_ui/swap_spec.rb
+++ b/spec/lib/phlexy_ui/swap_spec.rb
@@ -1,0 +1,111 @@
+require "spec_helper"
+
+describe PhlexyUI::Swap do
+  subject(:output) { render described_class.new }
+
+  it "is expected to match the formatted HTML" do
+    expected_html = html <<~HTML
+      <label class="swap"></label>
+    HTML
+
+    is_expected.to eq(expected_html)
+  end
+
+  describe "with part methods" do
+    subject(:output) do
+      render described_class.new do |s|
+        s.on { "On" }
+        s.off { "Off" }
+        s.indeterminate { "Indeterminate" }
+      end
+    end
+
+    it "renders all parts" do
+      expected_html = html <<~HTML
+        <label class="swap">
+          <div class="swap-on">On</div>
+          <div class="swap-off">Off</div>
+          <div class="swap-indeterminate">Indeterminate</div>
+        </label>
+      HTML
+
+      expect(output).to eq(expected_html)
+    end
+  end
+
+  describe "conditions" do
+    {
+      active: "swap-active",
+      rotate: "swap-rotate",
+      flip: "swap-flip"
+    }.each do |modifier, css|
+      context "when given :#{modifier} modifier" do
+        subject(:output) { render described_class.new(modifier) }
+
+        it "renders it apart from the main class" do
+          expected_html = html <<~HTML
+            <label class="swap #{css}"></label>
+          HTML
+
+          expect(output).to eq(expected_html)
+        end
+      end
+    end
+
+    context "when given multiple conditions" do
+      subject(:output) { render described_class.new(:active, :rotate) }
+
+      it "renders them separately" do
+        expected_html = html <<~HTML
+          <label class="swap swap-active swap-rotate"></label>
+        HTML
+
+        expect(output).to eq(expected_html)
+      end
+    end
+  end
+
+  describe "data" do
+    subject(:output) do
+      render described_class.new(data: {foo: "bar"})
+    end
+
+    it "renders it correctly" do
+      expected_html = html <<~HTML
+        <label class="swap" data-foo="bar"></label>
+      HTML
+
+      expect(output).to eq(expected_html)
+    end
+  end
+
+  describe "responsiveness" do
+    %i[sm md lg xl @sm @md @lg @xl].each do |viewport|
+      context "when given an :#{viewport} responsive option" do
+        subject(:output) do
+          render described_class.new(:rotate, responsive: {viewport => :flip})
+        end
+
+        it "renders it separately with a responsive prefix" do
+          expected_html = html <<~HTML
+            <label class="swap swap-rotate #{viewport}:swap-flip"></label>
+          HTML
+
+          expect(output).to eq(expected_html)
+        end
+      end
+    end
+  end
+
+  describe "passing :as option" do
+    subject(:output) { render described_class.new(as: :div) }
+
+    it "renders as the given tag" do
+      expected_html = html <<~HTML
+        <div class="swap"></div>
+      HTML
+
+      expect(output).to eq(expected_html)
+    end
+  end
+end


### PR DESCRIPTION
This PR adds the Swap component from #5.

## Changes
- Adds `PhlexyUI::Swap` component
- Includes comprehensive test coverage
- Follows PhlexyUI patterns and conventions

Part of breaking up #5 into individual component PRs.
