### PR TITLE
Add Textarea component

### DIFF
--- a/lib/phlexy_ui/textarea.rb
+++ b/lib/phlexy_ui/textarea.rb
@@ -1,0 +1,124 @@
+# frozen_string_literal: true
+
+module PhlexyUI
+  # @component html class="textarea"
+  class Textarea < Base
+    def initialize(*, as: :textarea, **)
+      super(*, **)
+      @as = as
+    end
+
+    def view_template(&)
+      generate_classes!(
+        # "textarea"
+        component_html_class: :textarea,
+        modifiers_map: modifiers,
+        base_modifiers:,
+        options:
+      ).then do |classes|
+        public_send(as, class: classes, **options, &)
+      end
+    end
+
+    register_modifiers(
+      # "sm:textarea-ghost"
+      # "@sm:textarea-ghost"
+      # "md:textarea-ghost"
+      # "@md:textarea-ghost"
+      # "lg:textarea-ghost"
+      # "@lg:textarea-ghost"
+      ghost: "textarea-ghost",
+      # "sm:textarea-xs"
+      # "@sm:textarea-xs"
+      # "md:textarea-xs"
+      # "@md:textarea-xs"
+      # "lg:textarea-xs"
+      # "@lg:textarea-xs"
+      xs: "textarea-xs",
+      # "sm:textarea-sm"
+      # "@sm:textarea-sm"
+      # "md:textarea-sm"
+      # "@md:textarea-sm"
+      # "lg:textarea-sm"
+      # "@lg:textarea-sm"
+      sm: "textarea-sm",
+      # "sm:textarea-md"
+      # "@sm:textarea-md"
+      # "md:textarea-md"
+      # "@md:textarea-md"
+      # "lg:textarea-md"
+      # "@lg:textarea-md"
+      md: "textarea-md",
+      # "sm:textarea-lg"
+      # "@sm:textarea-lg"
+      # "md:textarea-lg"
+      # "@md:textarea-lg"
+      # "lg:textarea-lg"
+      # "@lg:textarea-lg"
+      lg: "textarea-lg",
+      # "sm:textarea-xl"
+      # "@sm:textarea-xl"
+      # "md:textarea-xl"
+      # "@md:textarea-xl"
+      # "lg:textarea-xl"
+      # "@lg:textarea-xl"
+      xl: "textarea-xl",
+      # "sm:textarea-neutral"
+      # "@sm:textarea-neutral"
+      # "md:textarea-neutral"
+      # "@md:textarea-neutral"
+      # "lg:textarea-neutral"
+      # "@lg:textarea-neutral"
+      neutral: "textarea-neutral",
+      # "sm:textarea-primary"
+      # "@sm:textarea-primary"
+      # "md:textarea-primary"
+      # "@md:textarea-primary"
+      # "lg:textarea-primary"
+      # "@lg:textarea-primary"
+      primary: "textarea-primary",
+      # "sm:textarea-secondary"
+      # "@sm:textarea-secondary"
+      # "md:textarea-secondary"
+      # "@md:textarea-secondary"
+      # "lg:textarea-secondary"
+      # "@lg:textarea-secondary"
+      secondary: "textarea-secondary",
+      # "sm:textarea-accent"
+      # "@sm:textarea-accent"
+      # "md:textarea-accent"
+      # "@md:textarea-accent"
+      # "lg:textarea-accent"
+      # "@lg:textarea-accent"
+      accent: "textarea-accent",
+      # "sm:textarea-info"
+      # "@sm:textarea-info"
+      # "md:textarea-info"
+      # "@md:textarea-info"
+      # "lg:textarea-info"
+      # "@lg:textarea-info"
+      info: "textarea-info",
+      # "sm:textarea-success"
+      # "@sm:textarea-success"
+      # "md:textarea-success"
+      # "@md:textarea-success"
+      # "lg:textarea-success"
+      # "@lg:textarea-success"
+      success: "textarea-success",
+      # "sm:textarea-warning"
+      # "@sm:textarea-warning"
+      # "md:textarea-warning"
+      # "@md:textarea-warning"
+      # "lg:textarea-warning"
+      # "@lg:textarea-warning"
+      warning: "textarea-warning",
+      # "sm:textarea-error"
+      # "@sm:textarea-error"
+      # "md:textarea-error"
+      # "@md:textarea-error"
+      # "lg:textarea-error"
+      # "@lg:textarea-error"
+      error: "textarea-error"
+    )
+  end
+end

--- a/spec/lib/phlexy_ui/textarea_spec.rb
+++ b/spec/lib/phlexy_ui/textarea_spec.rb
@@ -1,0 +1,100 @@
+require "spec_helper"
+
+describe PhlexyUI::Textarea do
+  subject(:output) { render described_class.new }
+
+  it "is expected to match the formatted HTML" do
+    expected_html = html <<~HTML
+      <textarea class="textarea"></textarea>
+    HTML
+
+    is_expected.to eq(expected_html)
+  end
+
+  describe "conditions" do
+    {
+      ghost: "textarea-ghost",
+      xs: "textarea-xs",
+      sm: "textarea-sm",
+      md: "textarea-md",
+      lg: "textarea-lg",
+      xl: "textarea-xl",
+      neutral: "textarea-neutral",
+      primary: "textarea-primary",
+      secondary: "textarea-secondary",
+      accent: "textarea-accent",
+      info: "textarea-info",
+      success: "textarea-success",
+      warning: "textarea-warning",
+      error: "textarea-error"
+    }.each do |modifier, css|
+      context "when given :#{modifier} modifier" do
+        subject(:output) { render described_class.new(modifier) }
+
+        it "renders it apart from the main class" do
+          expected_html = html <<~HTML
+            <textarea class="textarea #{css}"></textarea>
+          HTML
+
+          expect(output).to eq(expected_html)
+        end
+      end
+    end
+
+    context "when given multiple conditions" do
+      subject(:output) { render described_class.new(:primary, :lg) }
+
+      it "renders them separately" do
+        expected_html = html <<~HTML
+          <textarea class="textarea textarea-primary textarea-lg"></textarea>
+        HTML
+
+        expect(output).to eq(expected_html)
+      end
+    end
+  end
+
+  describe "data" do
+    subject(:output) do
+      render described_class.new(data: {foo: "bar"})
+    end
+
+    it "renders it correctly" do
+      expected_html = html <<~HTML
+        <textarea class="textarea" data-foo="bar"></textarea>
+      HTML
+
+      expect(output).to eq(expected_html)
+    end
+  end
+
+  describe "responsiveness" do
+    %i[sm md lg xl @sm @md @lg @xl].each do |viewport|
+      context "when given an :#{viewport} responsive option" do
+        subject(:output) do
+          render described_class.new(:primary, responsive: {viewport => :secondary})
+        end
+
+        it "renders it separately with a responsive prefix" do
+          expected_html = html <<~HTML
+            <textarea class="textarea textarea-primary #{viewport}:textarea-secondary"></textarea>
+          HTML
+
+          expect(output).to eq(expected_html)
+        end
+      end
+    end
+  end
+
+  describe "passing :as option" do
+    subject(:output) { render described_class.new(as: :div) }
+
+    it "renders as the given tag" do
+      expected_html = html <<~HTML
+        <div class="textarea"></div>
+      HTML
+
+      expect(output).to eq(expected_html)
+    end
+  end
+end


### PR DESCRIPTION
This PR adds the Textarea component from #5.

## Changes
- Adds `PhlexyUI::Textarea` component
- Includes comprehensive test coverage
- Follows PhlexyUI patterns and conventions

Part of breaking up #5 into individual component PRs.
