### PR TITLE
Add Toast component

### DIFF
--- a/lib/phlexy_ui/toast.rb
+++ b/lib/phlexy_ui/toast.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+module PhlexyUI
+  # @component html class="toast"
+  class Toast < Base
+    def initialize(*, as: :div, **)
+      super(*, **)
+      @as = as
+    end
+
+    def view_template(&)
+      generate_classes!(
+        # "toast"
+        component_html_class: :toast,
+        modifiers_map: modifiers,
+        base_modifiers:,
+        options:
+      ).then do |classes|
+        public_send(as, class: classes, **options, &)
+      end
+    end
+
+    register_modifiers(
+      # "sm:toast-start"
+      # "@sm:toast-start"
+      # "md:toast-start"
+      # "@md:toast-start"
+      # "lg:toast-start"
+      # "@lg:toast-start"
+      start: "toast-start",
+      # "sm:toast-center"
+      # "@sm:toast-center"
+      # "md:toast-center"
+      # "@md:toast-center"
+      # "lg:toast-center"
+      # "@lg:toast-center"
+      center: "toast-center",
+        # "sm:toast-end"
+        # "@sm:toast-end"
+        # "md:toast-end"
+        # "@md:toast-end"
+        # "lg:toast-end"
+        # "@lg:toast-end"
+      end: "toast-end",
+      # "sm:toast-top"
+      # "@sm:toast-top"
+      # "md:toast-top"
+      # "@md:toast-top"
+      # "lg:toast-top"
+      # "@lg:toast-top"
+      top: "toast-top",
+      # "sm:toast-middle"
+      # "@sm:toast-middle"
+      # "md:toast-middle"
+      # "@md:toast-middle"
+      # "lg:toast-middle"
+      # "@lg:toast-middle"
+      middle: "toast-middle",
+      # "sm:toast-bottom"
+      # "@sm:toast-bottom"
+      # "md:toast-bottom"
+      # "@md:toast-bottom"
+      # "lg:toast-bottom"
+      # "@lg:toast-bottom"
+      bottom: "toast-bottom"
+    )
+  end
+end

--- a/spec/lib/phlexy_ui/toast_spec.rb
+++ b/spec/lib/phlexy_ui/toast_spec.rb
@@ -1,0 +1,92 @@
+require "spec_helper"
+
+describe PhlexyUI::Toast do
+  subject(:output) { render described_class.new }
+
+  it "is expected to match the formatted HTML" do
+    expected_html = html <<~HTML
+      <div class="toast"></div>
+    HTML
+
+    is_expected.to eq(expected_html)
+  end
+
+  describe "conditions" do
+    {
+      start: "toast-start",
+      center: "toast-center",
+      end: "toast-end",
+      top: "toast-top",
+      middle: "toast-middle",
+      bottom: "toast-bottom"
+    }.each do |modifier, css|
+      context "when given :#{modifier} modifier" do
+        subject(:output) { render described_class.new(modifier) }
+
+        it "renders it apart from the main class" do
+          expected_html = html <<~HTML
+            <div class="toast #{css}"></div>
+          HTML
+
+          expect(output).to eq(expected_html)
+        end
+      end
+    end
+
+    context "when given multiple conditions" do
+      subject(:output) { render described_class.new(:top, :end) }
+
+      it "renders them separately" do
+        expected_html = html <<~HTML
+          <div class="toast toast-top toast-end"></div>
+        HTML
+
+        expect(output).to eq(expected_html)
+      end
+    end
+  end
+
+  describe "data" do
+    subject(:output) do
+      render described_class.new(data: {foo: "bar"})
+    end
+
+    it "renders it correctly" do
+      expected_html = html <<~HTML
+        <div class="toast" data-foo="bar"></div>
+      HTML
+
+      expect(output).to eq(expected_html)
+    end
+  end
+
+  describe "responsiveness" do
+    %i[sm md lg xl @sm @md @lg @xl].each do |viewport|
+      context "when given an :#{viewport} responsive option" do
+        subject(:output) do
+          render described_class.new(:top, responsive: {viewport => :bottom})
+        end
+
+        it "renders it separately with a responsive prefix" do
+          expected_html = html <<~HTML
+            <div class="toast toast-top #{viewport}:toast-bottom"></div>
+          HTML
+
+          expect(output).to eq(expected_html)
+        end
+      end
+    end
+  end
+
+  describe "passing :as option" do
+    subject(:output) { render described_class.new(as: :aside) }
+
+    it "renders as the given tag" do
+      expected_html = html <<~HTML
+        <aside class="toast"></aside>
+      HTML
+
+      expect(output).to eq(expected_html)
+    end
+  end
+end


### PR DESCRIPTION
This PR adds the Toast component from #5.

## Changes
- Adds `PhlexyUI::Toast` component
- Includes comprehensive test coverage
- Follows PhlexyUI patterns and conventions

Part of breaking up #5 into individual component PRs.
