### PR TITLE
Add Toggle component

### DIFF
--- a/lib/phlexy_ui/toggle.rb
+++ b/lib/phlexy_ui/toggle.rb
@@ -1,0 +1,117 @@
+# frozen_string_literal: true
+
+module PhlexyUI
+  # @component html class="toggle"
+  class Toggle < Base
+    def initialize(*, as: :input, **)
+      super(*, **)
+      @as = as
+    end
+
+    def view_template(&)
+      generate_classes!(
+        # "toggle"
+        component_html_class: :toggle,
+        modifiers_map: modifiers,
+        base_modifiers:,
+        options:
+      ).then do |classes|
+        public_send(as, type: :checkbox, class: classes, **options, &)
+      end
+    end
+
+    register_modifiers(
+      # "sm:toggle-xs"
+      # "@sm:toggle-xs"
+      # "md:toggle-xs"
+      # "@md:toggle-xs"
+      # "lg:toggle-xs"
+      # "@lg:toggle-xs"
+      xs: "toggle-xs",
+      # "sm:toggle-sm"
+      # "@sm:toggle-sm"
+      # "md:toggle-sm"
+      # "@md:toggle-sm"
+      # "lg:toggle-sm"
+      # "@lg:toggle-sm"
+      sm: "toggle-sm",
+      # "sm:toggle-md"
+      # "@sm:toggle-md"
+      # "md:toggle-md"
+      # "@md:toggle-md"
+      # "lg:toggle-md"
+      # "@lg:toggle-md"
+      md: "toggle-md",
+      # "sm:toggle-lg"
+      # "@sm:toggle-lg"
+      # "md:toggle-lg"
+      # "@md:toggle-lg"
+      # "lg:toggle-lg"
+      # "@lg:toggle-lg"
+      lg: "toggle-lg",
+      # "sm:toggle-xl"
+      # "@sm:toggle-xl"
+      # "md:toggle-xl"
+      # "@md:toggle-xl"
+      # "lg:toggle-xl"
+      # "@lg:toggle-xl"
+      xl: "toggle-xl",
+      # "sm:toggle-primary"
+      # "@sm:toggle-primary"
+      # "md:toggle-primary"
+      # "@md:toggle-primary"
+      # "lg:toggle-primary"
+      # "@lg:toggle-primary"
+      primary: "toggle-primary",
+      # "sm:toggle-secondary"
+      # "@sm:toggle-secondary"
+      # "md:toggle-secondary"
+      # "@md:toggle-secondary"
+      # "lg:toggle-secondary"
+      # "@lg:toggle-secondary"
+      secondary: "toggle-secondary",
+      # "sm:toggle-accent"
+      # "@sm:toggle-accent"
+      # "md:toggle-accent"
+      # "@md:toggle-accent"
+      # "lg:toggle-accent"
+      # "@lg:toggle-accent"
+      accent: "toggle-accent",
+      # "sm:toggle-neutral"
+      # "@sm:toggle-neutral"
+      # "md:toggle-neutral"
+      # "@md:toggle-neutral"
+      # "lg:toggle-neutral"
+      # "@lg:toggle-neutral"
+      neutral: "toggle-neutral",
+      # "sm:toggle-success"
+      # "@sm:toggle-success"
+      # "md:toggle-success"
+      # "@md:toggle-success"
+      # "lg:toggle-success"
+      # "@lg:toggle-success"
+      success: "toggle-success",
+      # "sm:toggle-warning"
+      # "@sm:toggle-warning"
+      # "md:toggle-warning"
+      # "@md:toggle-warning"
+      # "lg:toggle-warning"
+      # "@lg:toggle-warning"
+      warning: "toggle-warning",
+      # "sm:toggle-info"
+      # "@sm:toggle-info"
+      # "md:toggle-info"
+      # "@md:toggle-info"
+      # "lg:toggle-info"
+      # "@lg:toggle-info"
+      info: "toggle-info",
+      # "sm:toggle-error"
+      # "@sm:toggle-error"
+      # "md:toggle-error"
+      # "@md:toggle-error"
+      # "lg:toggle-error"
+      # "@lg:toggle-error"
+      error: "toggle-error"
+    )
+  end
+end

--- a/spec/lib/phlexy_ui/toggle_spec.rb
+++ b/spec/lib/phlexy_ui/toggle_spec.rb
@@ -1,0 +1,99 @@
+require "spec_helper"
+
+describe PhlexyUI::Toggle do
+  subject(:output) { render described_class.new }
+
+  it "is expected to match the formatted HTML" do
+    expected_html = html <<~HTML
+      <input type="checkbox" class="toggle">
+    HTML
+
+    is_expected.to eq(expected_html)
+  end
+
+  describe "conditions" do
+    {
+      xs: "toggle-xs",
+      sm: "toggle-sm",
+      md: "toggle-md",
+      lg: "toggle-lg",
+      xl: "toggle-xl",
+      primary: "toggle-primary",
+      secondary: "toggle-secondary",
+      accent: "toggle-accent",
+      neutral: "toggle-neutral",
+      success: "toggle-success",
+      warning: "toggle-warning",
+      info: "toggle-info",
+      error: "toggle-error"
+    }.each do |modifier, css|
+      context "when given :#{modifier} modifier" do
+        subject(:output) { render described_class.new(modifier) }
+
+        it "renders it apart from the main class" do
+          expected_html = html <<~HTML
+            <input type="checkbox" class="toggle #{css}">
+          HTML
+
+          expect(output).to eq(expected_html)
+        end
+      end
+    end
+
+    context "when given multiple conditions" do
+      subject(:output) { render described_class.new(:primary, :lg) }
+
+      it "renders them separately" do
+        expected_html = html <<~HTML
+          <input type="checkbox" class="toggle toggle-primary toggle-lg">
+        HTML
+
+        expect(output).to eq(expected_html)
+      end
+    end
+  end
+
+  describe "data" do
+    subject(:output) do
+      render described_class.new(data: {foo: "bar"})
+    end
+
+    it "renders it correctly" do
+      expected_html = html <<~HTML
+        <input type="checkbox" class="toggle" data-foo="bar">
+      HTML
+
+      expect(output).to eq(expected_html)
+    end
+  end
+
+  describe "responsiveness" do
+    %i[sm md lg xl @sm @md @lg @xl].each do |viewport|
+      context "when given an :#{viewport} responsive option" do
+        subject(:output) do
+          render described_class.new(:primary, responsive: {viewport => :secondary})
+        end
+
+        it "renders it separately with a responsive prefix" do
+          expected_html = html <<~HTML
+            <input type="checkbox" class="toggle toggle-primary #{viewport}:toggle-secondary">
+          HTML
+
+          expect(output).to eq(expected_html)
+        end
+      end
+    end
+  end
+
+  describe "passing :as option" do
+    subject(:output) { render described_class.new(as: :div) }
+
+    it "renders as the given tag" do
+      expected_html = html <<~HTML
+        <div type="checkbox" class="toggle"></div>
+      HTML
+
+      expect(output).to eq(expected_html)
+    end
+  end
+end


### PR DESCRIPTION
This PR adds the Toggle component from #5.

## Changes
- Adds `PhlexyUI::Toggle` component
- Includes comprehensive test coverage
- Follows PhlexyUI patterns and conventions

Part of breaking up #5 into individual component PRs.
